### PR TITLE
refactor: parsing and argument validation are handled separately

### DIFF
--- a/service/internal/http_service/parser.go
+++ b/service/internal/http_service/parser.go
@@ -3,38 +3,32 @@ package httpservice
 import (
 	"fmt"
 	"strconv"
-	"strings"
-
-	"github.com/dirodriguezm/xmatch/service/internal/search/conesearch"
 )
 
 type ParseError struct {
-	Err      error
 	ErrValue string
 	Field    string
+	Reason   string
 }
 
 func (e ParseError) Error() string {
 	err := "Could not parse field %s with value %s:\n%s"
-	err = fmt.Sprintf(err, e.Field, e.ErrValue, e.Err.Error())
+	err = fmt.Sprintf(err, e.Field, e.ErrValue, e.Reason)
 	return err
 }
 
-func NewParseError(e error, errValue string, field string) error {
+func NewParseError(errValue, field, reason string) error {
 	return ParseError{
-		Err:      e,
 		ErrValue: errValue,
 		Field:    field,
+		Reason:   reason,
 	}
 }
 
 func parseRadius(rad string) (float64, error) {
 	radius, err := strconv.ParseFloat(rad, 64)
 	if err != nil {
-		return -999, NewParseError(err, rad, "radius")
-	}
-	if err := conesearch.ValidateRadius(radius); err != nil {
-		return -999, NewParseError(err, rad, "radius")
+		return -999, NewParseError(rad, "radius", "Could not parse float.")
 	}
 	return radius, nil
 }
@@ -42,10 +36,7 @@ func parseRadius(rad string) (float64, error) {
 func parseRa(ra string) (float64, error) {
 	parsedRa, err := strconv.ParseFloat(ra, 64)
 	if err != nil {
-		return -999, NewParseError(err, ra, "RA")
-	}
-	if err := conesearch.ValidateRa(parsedRa); err != nil {
-		return -999, NewParseError(err, ra, "RA")
+		return -999, NewParseError(ra, "RA", "Could not parse float.")
 	}
 	return parsedRa, nil
 }
@@ -53,37 +44,15 @@ func parseRa(ra string) (float64, error) {
 func parseDec(dec string) (float64, error) {
 	parsedDec, err := strconv.ParseFloat(dec, 64)
 	if err != nil {
-		return -999, NewParseError(err, dec, "Dec")
-	}
-	if err := conesearch.ValidateDec(parsedDec); err != nil {
-		return -999, NewParseError(err, dec, "Dec")
+		return -999, NewParseError(dec, "Dec", "Could not parse float.")
 	}
 	return parsedDec, nil
-}
-
-func parseCatalog(catalog string) (string, error) {
-	allowed := []string{"all", "wise", "vlass", "lsdr10"}
-	isAllowed := false
-	catalog = strings.ToLower(catalog)
-	for _, cat := range allowed {
-		if catalog == cat {
-			isAllowed = true
-			break
-		}
-	}
-	if !isAllowed {
-		return "", NewParseError(fmt.Errorf("Only %s catalogs are available. Catalog %s not found.", allowed, catalog), catalog, "catalog")
-	}
-	return catalog, nil
 }
 
 func parseNneighbor(nneighbor string) (int, error) {
 	parsedNneighbor, err := strconv.Atoi(nneighbor)
 	if err != nil {
-		return -999, NewParseError(err, nneighbor, "nneighbor")
-	}
-	if err := conesearch.ValidateNneighbor(parsedNneighbor); err != nil {
-		return -999, NewParseError(err, nneighbor, "nneighbor")
+		return -999, NewParseError(nneighbor, "nneighbor", "Could not parse int.")
 	}
 	return parsedNneighbor, nil
 }

--- a/service/internal/http_service/server_validation_test.go
+++ b/service/internal/http_service/server_validation_test.go
@@ -10,8 +10,7 @@ func TestRaValidation(t *testing.T) {
 	testCases := map[string]float64{
 		"":    -999,
 		"aaa": -999,
-		"-1":  -999,
-		"361": -999,
+		"-1":  -1,
 		"0":   0,
 		"1":   1,
 		"360": 360,
@@ -28,9 +27,7 @@ func TestDecValidation(t *testing.T) {
 	testCases := map[string]float64{
 		"":    -999,
 		"aaa": -999,
-		"-91": -999,
-		"91":  -999,
-		"-90": -90,
+		"-1":  -1,
 		"90":  90,
 		"5.5": 5.5,
 	}
@@ -45,8 +42,8 @@ func TestRadiusValidation(t *testing.T) {
 	testCases := map[string]float64{
 		"":    -999,
 		"aaa": -999,
-		"-1":  -999,
-		"0":   -999,
+		"-1":  -1,
+		"0":   0,
 		"1":   1,
 		"5.5": 5.5,
 	}
@@ -57,30 +54,12 @@ func TestRadiusValidation(t *testing.T) {
 	}
 }
 
-func TestCatalogValidation(t *testing.T) {
-	testCases := map[string]string{
-		"all":            "all",
-		"wise":           "wise",
-		"vlass":          "vlass",
-		"lsdr10":         "lsdr10",
-		"ALL":            "all",
-		"WISE":           "wise",
-		"VLASS":          "vlass",
-		"LSDR10":         "lsdr10",
-		"something else": "",
-	}
-	for testCase, expectedResult := range testCases {
-		result, _ := parseCatalog(testCase)
-		require.Equal(t, expectedResult, result)
-	}
-}
-
 func TestNneighborValidation(t *testing.T) {
 	testCases := map[string]int{
 		"":    -999,
 		"aaa": -999,
-		"-1":  -999,
-		"0":   -999,
+		"-1":  -1,
+		"0":   0,
 		"1":   1,
 	}
 	for testCase, expectedResult := range testCases {

--- a/service/internal/search/conesearch/conesearch.go
+++ b/service/internal/search/conesearch/conesearch.go
@@ -74,7 +74,11 @@ func createServiceMappers(catalogs []repository.Catalog, scheme healpix.Ordering
 	return mappers, nil
 }
 
-func (c *ConesearchService) Conesearch(ra, dec, radius float64, nneighbor int) ([]repository.Mastercat, error) {
+func (c *ConesearchService) Conesearch(ra, dec, radius float64, nneighbor int, catalog string) ([]repository.Mastercat, error) {
+	if err := ValidateArguments(ra, dec, radius, nneighbor, catalog); err != nil {
+		return nil, err
+	}
+
 	radius_radians := arcsecToRadians(radius)
 	point := healpix.RADec(float64(ra), float64(dec))
 	objects := make([]repository.Mastercat, 0)
@@ -87,6 +91,7 @@ func (c *ConesearchService) Conesearch(ra, dec, radius float64, nneighbor int) (
 		}
 		objects = append(objects, objs...)
 	}
+
 	objects = knn.NearestNeighborSearch(objects, ra, dec, radius, nneighbor)
 	return objects, nil
 }

--- a/service/internal/search/conesearch/conesearch_integration_test.go
+++ b/service/internal/search/conesearch/conesearch_integration_test.go
@@ -108,7 +108,7 @@ func TestConesearch(t *testing.T) {
 		repo.InsertObject(context.Background(), obj)
 	}
 
-	result, err := service.Conesearch(0, 0, 1, 10)
+	result, err := service.Conesearch(0, 0, 1, 10, "all")
 	if err != nil {
 		t.Error(err)
 	}

--- a/service/internal/search/conesearch/conesearch_test.go
+++ b/service/internal/search/conesearch/conesearch_test.go
@@ -24,7 +24,7 @@ func TestConesearch(t *testing.T) {
 	service, err := NewConesearchService(WithScheme(healpix.Nest), WithRepository(repo), WithCatalogs(catalogs))
 	require.NoError(t, err)
 
-	result, err := service.Conesearch(1, 1, 1, 1)
+	result, err := service.Conesearch(1, 1, 1, 1, "all")
 	require.NoError(t, err)
 	repo.AssertExpectations(t)
 
@@ -39,7 +39,7 @@ func TestConesearch_WithRepositoryError(t *testing.T) {
 	service, err := NewConesearchService(WithScheme(healpix.Nest), WithRepository(repo), WithCatalogs(catalogs))
 	require.NoError(t, err)
 
-	_, err = service.Conesearch(1, 1, 1, 1)
+	_, err = service.Conesearch(1, 1, 1, 1, "all")
 	repo.AssertExpectations(t)
 	if assert.Error(t, err) {
 		require.Equal(t, errors.New("Test error"), err)
@@ -61,7 +61,7 @@ func TestConesearch_WithMultipleMappers(t *testing.T) {
 	service, err := NewConesearchService(WithScheme(healpix.Nest), WithRepository(repo), WithCatalogs(catalogs))
 	require.NoError(t, err)
 
-	result, err := service.Conesearch(1, 1, 1, 2)
+	result, err := service.Conesearch(1, 1, 1, 2, "all")
 	repo.AssertExpectations(t)
 
 	// both objects in the result should be in the same coordinates, but different catalog
@@ -89,7 +89,7 @@ func FuzzConesearch(f *testing.F) {
 
 	f.Add(float64(1), float64(1), float64(1), int(1))
 	f.Fuzz(func(t *testing.T, ra float64, dec float64, radius float64, nneighbor int) {
-		_, err := service.Conesearch(ra, dec, radius, nneighbor)
+		_, err := service.Conesearch(ra, dec, radius, nneighbor, "all")
 		if err == nil {
 			repo.AssertExpectations(t)
 		}


### PR DESCRIPTION
Argument validation is done in the conesearch service only. HTTP argument parsing no longer validates the input. It delegates that to the service and the result is handled with a status 400.