### PR TITLE
feat: add mastercat conversion methods

### DIFF
--- a/service/internal/catalog_indexer/writer/parquet/parquet_writer.go
+++ b/service/internal/catalog_indexer/writer/parquet/parquet_writer.go
@@ -82,6 +82,9 @@ func convertMapToStruct[T any](data indexer.Row) T {
 
 	// Helper function to convert snake_case to PascalCase
 	toPascalCase := func(s string) string {
+		if s == "id" {
+			return "ID"
+		}
 		parts := strings.Split(s, "_")
 		for i, part := range parts {
 			if len(part) > 0 {

--- a/service/internal/catalog_indexer/writer/parquet/schema.go
+++ b/service/internal/catalog_indexer/writer/parquet/schema.go
@@ -1,9 +1,0 @@
-package parquet_writer
-
-type IndexerSchema struct {
-	Id   string  `parquet:"name=id, type=BYTE_ARRAY"`
-	Ra   float64 `parquet:"name=ra, type=DOUBLE"`
-	Dec  float64 `parquet:"name=dec, type=DOUBLE"`
-	Ipix int     `parquet:"name=ipix, type=INT64"`
-	Cat  string  `parquet:"name=cat, type=BYTE_ARRAY"`
-}

--- a/service/internal/di/indexer_container.go
+++ b/service/internal/di/indexer_container.go
@@ -109,7 +109,7 @@ func BuildIndexerContainer() container.Container {
 		}
 		switch cfg.CatalogIndexer.IndexerWriter.Type {
 		case "parquet":
-			w, err := parquet_writer.NewParquetWriter[parquet_writer.IndexerSchema](writerInput, make(chan bool), cfg.CatalogIndexer.IndexerWriter)
+			w, err := parquet_writer.NewParquetWriter[repository.ParquetMastercat](writerInput, make(chan bool), cfg.CatalogIndexer.IndexerWriter)
 			if err != nil {
 				panic(err)
 			}

--- a/service/internal/repository/mastercat.go
+++ b/service/internal/repository/mastercat.go
@@ -1,0 +1,29 @@
+package repository
+
+type ParquetMastercat struct {
+	ID   string  `parquet:"name=id, type=BYTE_ARRAY"`
+	Ipix int64   `parquet:"name=ipix, type=INT64"`
+	Ra   float64 `parquet:"name=ra, type=DOUBLE"`
+	Dec  float64 `parquet:"name=dec, type=DOUBLE"`
+	Cat  string  `parquet:"name=cat, type=BYTE_ARRAY"`
+}
+
+func (m Mastercat) ToInsertObjectParams() InsertObjectParams {
+	return InsertObjectParams{
+		ID:   m.ID,
+		Ipix: m.Ipix,
+		Ra:   m.Ra,
+		Dec:  m.Dec,
+		Cat:  m.Cat,
+	}
+}
+
+func (m Mastercat) ToParquetMastercat() ParquetMastercat {
+	return ParquetMastercat{
+		ID:   m.ID,
+		Ipix: m.Ipix,
+		Ra:   m.Ra,
+		Dec:  m.Dec,
+		Cat:  m.Cat,
+	}
+}

--- a/service/internal/repository/mastercat_test.go
+++ b/service/internal/repository/mastercat_test.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToInsertObjectParams(t *testing.T) {
+	m := Mastercat{
+		ID:   "id",
+		Ipix: 1,
+		Ra:   1,
+		Dec:  1,
+		Cat:  "cat",
+	}
+	result := m.ToInsertObjectParams()
+	require.Equal(t, m.ID, result.ID)
+	require.Equal(t, m.Ipix, result.Ipix)
+	require.Equal(t, m.Ra, result.Ra)
+	require.Equal(t, m.Dec, result.Dec)
+	require.Equal(t, m.Cat, result.Cat)
+}
+
+func TestToParquetMastercat(t *testing.T) {
+	m := Mastercat{
+		ID:   "id",
+		Ipix: 1,
+		Ra:   1,
+		Dec:  1,
+		Cat:  "cat",
+	}
+	result := m.ToParquetMastercat()
+	require.Equal(t, m.ID, result.ID)
+	require.Equal(t, m.Ipix, result.Ipix)
+	require.Equal(t, m.Ra, result.Ra)
+	require.Equal(t, m.Dec, result.Dec)
+	require.Equal(t, m.Cat, result.Cat)
+}


### PR DESCRIPTION
To be used with this design
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/aa37c9d4-b8d6-47bf-b929-69e3e664a2ab" />

# Copilot summary 🙄 
This pull request includes significant changes to the `service/internal` package, primarily focused on migrating the schema for Parquet files from `parquet_writer` to `repository`. The most important changes include the introduction of the `ParquetMastercat` struct, updates to the integration tests, and the removal of the old `IndexerSchema` struct.

Schema migration:

* Introduced the `ParquetMastercat` struct in `service/internal/repository/mastercat.go`, which replaces the old `IndexerSchema` struct. This includes methods for converting to insert object parameters and to the new Parquet schema.
* Removed the `IndexerSchema` struct from `service/internal/catalog_indexer/writer/parquet/schema.go`.

Integration test updates:

* Updated the import statements and test logic in `service/internal/catalog_indexer/writer/parquet/parquet_writer_integration_test.go` to use the new `ParquetMastercat` struct. [[1]](diffhunk://#diff-5b8a41ea20a40fbe912dc17ed7aabe096fa366d10e38afa349fc775b0101e1fcR14) [[2]](diffhunk://#diff-5b8a41ea20a40fbe912dc17ed7aabe096fa366d10e38afa349fc775b0101e1fcL72-R89)

Configuration updates:

* Modified the `BuildIndexerContainer` function in `service/internal/di/indexer_container.go` to instantiate the `ParquetWriter` with the new `ParquetMastercat` struct.

Helper function enhancement:

* Enhanced the `toPascalCase` function in `service/internal/catalog_indexer/writer/parquet/parquet_writer.go` to handle the special case for the "id" field.