### PR TITLE
feat: reader has multiple output channels

### DIFF
--- a/service/config.yaml
+++ b/service/config.yaml
@@ -18,6 +18,8 @@ catalog_indexer:
     oid_col: "id"
     # Nside of the HEALPix grid
     nside: 18
+    # Wether to index metadata
+    metadata: true
   reader:
     # size of the batch to read from the input file
     batch_size: 500

--- a/service/internal/catalog_indexer/reader/csv/csv_reader.go
+++ b/service/internal/catalog_indexer/reader/csv/csv_reader.go
@@ -19,7 +19,7 @@ type CsvReader struct {
 	currentReader   int
 }
 
-func NewCsvReader(src *source.Source, channel chan indexer.ReaderResult, opts ...CsvReaderOption) (*CsvReader, error) {
+func NewCsvReader(src *source.Source, channel []chan indexer.ReaderResult, opts ...CsvReaderOption) (*CsvReader, error) {
 	readers := []*csv.Reader{}
 	for _, reader := range src.Reader {
 		readers = append(readers, csv.NewReader(reader))

--- a/service/internal/catalog_indexer/reader/csv/csv_reader_integration_test.go
+++ b/service/internal/catalog_indexer/reader/csv/csv_reader_integration_test.go
@@ -62,14 +62,16 @@ func TestReadMultipleFiles_Csv(t *testing.T) {
 	// collect results
 	allRows := make([]repository.InputSchema, 0)
 	var err error
-	for msg := range fixture.reader.OutputChannel {
-		if msg.Error != nil {
-			err = msg.Error
-			break
+	for i := range fixture.reader.OutputChannel {
+		for msg := range fixture.reader.OutputChannel[i] {
+			if msg.Error != nil {
+				err = msg.Error
+				break
+			}
+			allRows = append(allRows, msg.Rows...)
 		}
-		allRows = append(allRows, msg.Rows...)
+		require.NoError(t, err)
 	}
-	require.NoError(t, err)
 
 	// assert
 	require.Len(t, allRows, 10)
@@ -107,9 +109,12 @@ o2,2,2
 
 	// collect results
 	allRows := make([]repository.InputSchema, 0)
-	for msg := range fixture.reader.OutputChannel {
-		for _, row := range msg.Rows {
-			allRows = append(allRows, row)
+	for i := range fixture.reader.OutputChannel {
+		for msg := range fixture.reader.OutputChannel[i] {
+			require.NoError(t, msg.Error)
+			for _, row := range msg.Rows {
+				allRows = append(allRows, row)
+			}
 		}
 	}
 

--- a/service/internal/catalog_indexer/reader/csv/test_helpers.go
+++ b/service/internal/catalog_indexer/reader/csv/test_helpers.go
@@ -15,10 +15,12 @@ type ReaderBuilder struct {
 	ReaderConfig  *config.ReaderConfig
 	t             *testing.T
 	Source        *source.Source
-	OutputChannel chan indexer.ReaderResult
+	OutputChannel []chan indexer.ReaderResult
 }
 
 func AReader(t *testing.T) *ReaderBuilder {
+	outputs := make([]chan indexer.ReaderResult, 1)
+	outputs[0] = make(chan indexer.ReaderResult)
 	return &ReaderBuilder{
 		t: t,
 		ReaderConfig: &config.ReaderConfig{
@@ -26,7 +28,7 @@ func AReader(t *testing.T) *ReaderBuilder {
 			FirstLineHeader: true,
 			BatchSize:       1,
 		},
-		OutputChannel: make(chan indexer.ReaderResult),
+		OutputChannel: outputs,
 	}
 }
 
@@ -47,7 +49,7 @@ func (builder *ReaderBuilder) WithBatchSize(size int) *ReaderBuilder {
 	return builder
 }
 
-func (builder *ReaderBuilder) WithOutputChannel(ch chan indexer.ReaderResult) *ReaderBuilder {
+func (builder *ReaderBuilder) WithOutputChannels(ch []chan indexer.ReaderResult) *ReaderBuilder {
 	builder.t.Helper()
 
 	builder.OutputChannel = ch

--- a/service/internal/catalog_indexer/reader/factory/reader_factory.go
+++ b/service/internal/catalog_indexer/reader/factory/reader_factory.go
@@ -14,7 +14,7 @@ import (
 
 func ReaderFactory(
 	src *source.Source,
-	outbox chan indexer.ReaderResult,
+	outbox []chan indexer.ReaderResult,
 	cfg *config.ReaderConfig,
 ) (indexer.Reader, error) {
 	readerType := strings.ToLower(cfg.Type)
@@ -34,7 +34,7 @@ func ReaderFactory(
 	}
 }
 
-func parquetFactory(src *source.Source, outbox chan indexer.ReaderResult, cfg *config.ReaderConfig) (indexer.Reader, error) {
+func parquetFactory(src *source.Source, outbox []chan indexer.ReaderResult, cfg *config.ReaderConfig) (indexer.Reader, error) {
 	catalog := strings.ToLower(src.CatalogName)
 	if catalog == "allwise" {
 		return parquet_reader.NewParquetReader(

--- a/service/internal/catalog_indexer/reader/parquet/parquet_reader.go
+++ b/service/internal/catalog_indexer/reader/parquet/parquet_reader.go
@@ -21,14 +21,14 @@ type ParquetReader[T any] struct {
 	parquetReaders []*preader.ParquetReader
 	src            *source.Source
 	currentReader  int
-	outbox         chan indexer.ReaderResult
+	outbox         []chan indexer.ReaderResult
 
 	fileReaders []psource.ParquetFile
 }
 
 func NewParquetReader[T any](
 	src *source.Source,
-	channel chan indexer.ReaderResult,
+	channel []chan indexer.ReaderResult,
 	opts ...ParquetReaderOption[T],
 ) (*ParquetReader[T], error) {
 	readers := []*preader.ParquetReader{}

--- a/service/internal/catalog_indexer/reader/parquet/parquet_reader_test.go
+++ b/service/internal/catalog_indexer/reader/parquet/parquet_reader_test.go
@@ -71,7 +71,11 @@ func TestReadParquet_read_all_file(t *testing.T) {
 		CatalogName: "test",
 	}
 
-	parquetReader, err := NewParquetReader[Object](&source, make(chan indexer.ReaderResult))
+	outputs := make([]chan indexer.ReaderResult, 1)
+	for i := range outputs {
+		outputs[i] = make(chan indexer.ReaderResult)
+	}
+	parquetReader, err := NewParquetReader[Object](&source, outputs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +103,11 @@ func TestReadParquet_read_batch_single_file(t *testing.T) {
 		CatalogName: "test",
 	}
 
-	parquetReader, err := NewParquetReader(&source, make(chan indexer.ReaderResult), WithParquetBatchSize[Object](2))
+	outputs := make([]chan indexer.ReaderResult, 1)
+	for i := range outputs {
+		outputs[i] = make(chan indexer.ReaderResult)
+	}
+	parquetReader, err := NewParquetReader(&source, outputs, WithParquetBatchSize[Object](2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +142,11 @@ func TestReadParquet_read_batch_single_file_with_empty_batches(t *testing.T) {
 		CatalogName: "test",
 	}
 
-	parquetReader, err := NewParquetReader(&source, make(chan indexer.ReaderResult), WithParquetBatchSize[Object](2))
+	outputs := make([]chan indexer.ReaderResult, 1)
+	for i := range outputs {
+		outputs[i] = make(chan indexer.ReaderResult)
+	}
+	parquetReader, err := NewParquetReader(&source, outputs, WithParquetBatchSize[Object](2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +181,11 @@ func TestReadParquet_read_batch_larger_than_rows(t *testing.T) {
 		CatalogName: "test",
 	}
 
-	parquetReader, err := NewParquetReader(&source, make(chan indexer.ReaderResult), WithParquetBatchSize[Object](5))
+	outputs := make([]chan indexer.ReaderResult, 1)
+	for i := range outputs {
+		outputs[i] = make(chan indexer.ReaderResult)
+	}
+	parquetReader, err := NewParquetReader(&source, outputs, WithParquetBatchSize[Object](5))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/internal/catalog_indexer/reader/parquet/test_helpers.go
+++ b/service/internal/catalog_indexer/reader/parquet/test_helpers.go
@@ -45,10 +45,12 @@ type ReaderBuilder[T any] struct {
 	ReaderConfig  *config.ReaderConfig
 	t             *testing.T
 	Source        *source.Source
-	OutputChannel chan indexer.ReaderResult
+	OutputChannel []chan indexer.ReaderResult
 }
 
 func AReader[T any](t *testing.T) *ReaderBuilder[T] {
+	outputs := make([]chan indexer.ReaderResult, 1)
+	outputs[0] = make(chan indexer.ReaderResult)
 	return &ReaderBuilder[T]{
 		t: t,
 		ReaderConfig: &config.ReaderConfig{
@@ -56,7 +58,7 @@ func AReader[T any](t *testing.T) *ReaderBuilder[T] {
 			FirstLineHeader: true,
 			BatchSize:       1,
 		},
-		OutputChannel: make(chan indexer.ReaderResult),
+		OutputChannel: outputs,
 	}
 }
 
@@ -77,7 +79,7 @@ func (builder *ReaderBuilder[T]) WithBatchSize(size int) *ReaderBuilder[T] {
 	return builder
 }
 
-func (builder *ReaderBuilder[T]) WithOutputChannel(ch chan indexer.ReaderResult) *ReaderBuilder[T] {
+func (builder *ReaderBuilder[T]) WithOutputChannels(ch []chan indexer.ReaderResult) *ReaderBuilder[T] {
 	builder.t.Helper()
 
 	builder.OutputChannel = ch

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -33,6 +33,7 @@ type SourceConfig struct {
 	DecCol      string `yaml:"dec_col"`
 	OidCol      string `yaml:"oid_col"`
 	Nside       int    `yaml:"nside"`
+	Metadata    bool   `yaml:"metadata"`
 }
 
 type ReaderConfig struct {


### PR DESCRIPTION
This pull request includes several changes to the `catalog_indexer` service, focusing on supporting multiple output channels for readers and improving the handling of metadata indexing. The most important changes include modifications to the `BaseReader`, `CsvReader` and `ParquetReader` structures, updates to various test files, and the addition of a new test case to handle multiple output channels.

### Support for Multiple Output Channels:

* [`service/internal/catalog_indexer/reader/base_reader.go`](diffhunk://#diff-970c1e1fc7e38043be82f404f24bc79e713cbf43c8f4ec1be334e42a75c5340dL15-R24): Changed the `Outbox` field from a single channel to a slice of channels, and updated the `Start` method to handle multiple output channels. [[1]](diffhunk://#diff-970c1e1fc7e38043be82f404f24bc79e713cbf43c8f4ec1be334e42a75c5340dL15-R24) [[2]](diffhunk://#diff-970c1e1fc7e38043be82f404f24bc79e713cbf43c8f4ec1be334e42a75c5340dL33-R37) [[3]](diffhunk://#diff-970c1e1fc7e38043be82f404f24bc79e713cbf43c8f4ec1be334e42a75c5340dL42-R48)
* [`service/internal/catalog_indexer/reader/csv/csv_reader.go`](diffhunk://#diff-9dd6f4ab36e1b025a46f79379c85ea313e4cf794f7c55788a16367f5c8294757L22-R22): Updated the `NewCsvReader` function to accept a slice of channels instead of a single channel.
* [`service/internal/catalog_indexer/reader/csv/csv_reader_test.go`](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88L30-R34): Modified test cases to accommodate the changes in the `CsvReader` structure, including creating multiple output channels and reading from them concurrently. [[1]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88L30-R34) [[2]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88R67-R70) [[3]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88R127-R131) [[4]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88R181-R185) [[5]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88R235-R239) [[6]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88L265-R308) [[7]](diffhunk://#diff-8915a6bbe818b16814967b4e28144636717b49013eee3debe97c7ebf8cc1cc88R317-R381)
* [`service/internal/catalog_indexer/reader/parquet/parquet_reader.go`](diffhunk://#diff-e798ad247b3902c9a0eb70b529b0e48790d1f30863d546cd1e168e7dc77f820eL24-R31): Updated the `NewParquetReader` function to accept a slice of channels and modified the structure accordingly.
* [`service/internal/catalog_indexer/reader/parquet/parquet_reader_test.go`](diffhunk://#diff-d8d0c110ca58dbd61749e9efe453eead0574df6cf6ba67f06f4409d7ee9ae0b1L74-R78): Added and updated test cases to handle multiple output channels for the `ParquetReader`. [[1]](diffhunk://#diff-d8d0c110ca58dbd61749e9efe453eead0574df6cf6ba67f06f4409d7ee9ae0b1L74-R78) [[2]](diffhunk://#diff-d8d0c110ca58dbd61749e9efe453eead0574df6cf6ba67f06f4409d7ee9ae0b1L102-R110) [[3]](diffhunk://#diff-d8d0c110ca58dbd61749e9efe453eead0574df6cf6ba67f06f4409d7ee9ae0b1L137-R149) [[4]](diffhunk://#diff-d8d0c110ca58dbd61749e9efe453eead0574df6cf6ba67f06f4409d7ee9ae0b1L172-R188)

### Metadata Indexing:

* [`service/config.yaml`](diffhunk://#diff-be0fe38393c7468369eb27f5a81ec53de63a8fcd75b02219be07b4aacace1c47R21-R22): Added a new configuration option to enable or disable metadata indexing.

### Additional Changes:

* [`service/internal/catalog_indexer/reader/csv/test_helpers.go`](diffhunk://#diff-bd6391c089fb530b7e35c694056507d7733cde15b2fab690e8e5600ccbb1e998L18-R31): Updated helper functions to support multiple output channels. [[1]](diffhunk://#diff-bd6391c089fb530b7e35c694056507d7733cde15b2fab690e8e5600ccbb1e998L18-R31) [[2]](diffhunk://#diff-bd6391c089fb530b7e35c694056507d7733cde15b2fab690e8e5600ccbb1e998L50-R52)
* [`service/internal/catalog_indexer/reader/factory/reader_factory.go`](diffhunk://#diff-f9b9d8ad89b22ec08b8f26318450cb46574c84f88f21d7c0b9c5cdc167b33ee6L17-R17): Modified the `ReaderFactory` and `parquetFactory` functions to accept a slice of channels. [[1]](diffhunk://#diff-f9b9d8ad89b22ec08b8f26318450cb46574c84f88f21d7c0b9c5cdc167b33ee6L17-R17) [[2]](diffhunk://#diff-f9b9d8ad89b22ec08b8f26318450cb46574c84f88f21d7c0b9c5cdc167b33ee6L37-R37)
* [`service/internal/catalog_indexer/reader/parquet/parquet_reader_integration_test.go`](diffhunk://#diff-0bc5a2de3c244d132203711069e0797bcc4d90abac5b03522fe293d3bf933963R116-R172): Added a new test case to verify the functionality of multiple output channels in the `ParquetReader`.