### PR TITLE
feat: add cpu profiling with -profile flag

### DIFF
--- a/service/cmd/main.go
+++ b/service/cmd/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"os"
+	"runtime/pprof"
 
 	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/indexer"
 	"github.com/dirodriguezm/xmatch/service/internal/di"
@@ -46,15 +48,25 @@ func startCatalogIndexer() {
 }
 
 func main() {
+	slog.Info("Starting xmatch service")
+	profile := flag.CommandLine.Bool("profile", false, "Enable profiling")
 	flag.Parse()
 	command := flag.Arg(0)
-	fmt.Println(flag.Args())
+
+	if *profile {
+		slog.Info("Profiling enabled")
+		cpuFile, _ := os.Create("cpu.prof")
+		defer cpuFile.Close()
+		pprof.StartCPUProfile(cpuFile)
+		defer pprof.StopCPUProfile()
+	}
+
 	switch command {
 	case "server":
 		startHttpServer()
 	case "indexer":
 		startCatalogIndexer()
 	default:
-		fmt.Print("Unknown command\n")
+		fmt.Printf("Unknown command: %s\n", command)
 	}
 }

--- a/service/justfile
+++ b/service/justfile
@@ -12,8 +12,8 @@ test:
 
 export CONFIG_PATH := env_var_or_default("CONFIG_PATH", "config.yaml")
 
-run application $LOG_LEVEL="debug": build
-	./build/main {{application}}
+run application flags='' $LOG_LEVEL="debug": build
+	./build/main {{flags}} {{application}}
 
 clean-build:
 	rm -r build


### PR DESCRIPTION
This pull request introduces new profiling capabilities, enhances logging, and updates the `justfile` for running the application with additional flags.

Enhancements:

* [`service/cmd/main.go`](diffhunk://#diff-d102112eada55bead641c1d87da147104a1c32fecaf6829bb2a0d464b72ab3b3R7-R8): Added imports for `os` and `runtime/pprof` to enable CPU profiling.
* [`service/cmd/main.go`](diffhunk://#diff-d102112eada55bead641c1d87da147104a1c32fecaf6829bb2a0d464b72ab3b3R51-R70): Introduced a `profile` flag to enable profiling, added logging for profiling status, and improved the unknown command message.

Updates to `justfile`:

* [`service/justfile`](diffhunk://#diff-5fc41d84145886127d40cb82ea721ce75d131fdeb9869943efc9d90a752cfd25L15-R16): Modified the `run` recipe to accept additional flags for running the application.