### PR TITLE
Changes to distance metrics and AllWISE catalog compatibility

### DIFF
--- a/service/internal/catalog_indexer/indexer/metadata/allwise/allwise_actor_test.go
+++ b/service/internal/catalog_indexer/indexer/metadata/allwise/allwise_actor_test.go
@@ -16,13 +16,13 @@ func TestStart(t *testing.T) {
 	actor.Start()
 	rows := make([]repository.InputSchema, 10)
 	for i := 0; i < 10; i++ {
-		designation := "test"
+		source_id := "test"
 		w1mpro := 1.0
 		w1sigmpro := 1.0
 		w2mpro := 2.0
 		w2sigmpro := 2.0
 		rows[i] = &repository.AllwiseInputSchema{
-			Designation: &designation,
+			Source_id: &source_id,
 			W1mpro:      &w1mpro,
 			W1sigmpro:   &w1sigmpro,
 			W2mpro:      &w2mpro,
@@ -39,7 +39,7 @@ func TestStart(t *testing.T) {
 		require.NoError(t, msg.Error)
 		require.Len(t, msg.Rows, 10)
 		for i := 0; i < 10; i++ {
-			require.Equal(t, "test", *msg.Rows[i].Designation)
+			require.Equal(t, "test", *msg.Rows[i].Source_id)
 			require.Equal(t, 1.0, *msg.Rows[i].W1mpro)
 			require.Equal(t, 1.0, *msg.Rows[i].W1sigmpro)
 			require.Equal(t, 2.0, *msg.Rows[i].W2mpro)

--- a/service/internal/catalog_indexer/reader/parquet/parquet_reader.go
+++ b/service/internal/catalog_indexer/reader/parquet/parquet_reader.go
@@ -158,7 +158,7 @@ func convertToInputSchema[T any](records []T, catalogName string) []repository.I
 		switch catalogName {
 		case "allwise":
 			inputSchemas[i] = &repository.AllwiseInputSchema{}
-			inputSchemas[i].SetField("Designation", elem.FieldByName("Designation").Interface())
+			inputSchemas[i].SetField("Source_id", elem.FieldByName("Source_id").Interface())
 			inputSchemas[i].SetField("Ra", elem.FieldByName("Ra").Interface())
 			inputSchemas[i].SetField("Dec", elem.FieldByName("Dec").Interface())
 			inputSchemas[i].SetField("W1mpro", elem.FieldByName("W1mpro").Interface())

--- a/service/internal/catalog_indexer/writer/sqlite/sqlite_writer_test.go
+++ b/service/internal/catalog_indexer/writer/sqlite/sqlite_writer_test.go
@@ -52,13 +52,13 @@ func TestStart_Mastercat(t *testing.T) {
 }
 
 func TestStart_Allwise(t *testing.T) {
-	designation := "test"
+	source_id := "test"
 	w1mpro := 1.0
 	w1sigmpro := 1.0
 	w2mpro := 2.0
 	w2sigmpro := 2.0
 	allwise := repository.AllwiseMetadata{
-		Designation: &designation,
+		Source_id: &source_id,
 		W1mpro:      &w1mpro,
 		W1sigmpro:   &w1sigmpro,
 		W2mpro:      &w2mpro,

--- a/service/internal/repository/input_schema.go
+++ b/service/internal/repository/input_schema.go
@@ -8,7 +8,7 @@ type InputSchema interface {
 }
 
 type AllwiseInputSchema struct {
-	Designation  *string  `parquet:"name=designation, type=BYTE_ARRAY"`
+	Source_id  *string  `parquet:"name=source_id, type=BYTE_ARRAY"`
 	Ra           *float64 `parquet:"name=ra, type=DOUBLE"`
 	Dec          *float64 `parquet:"name=dec, type=DOUBLE"`
 	W1mpro       *float64 `parquet:"name=w1mpro, type=DOUBLE"`
@@ -31,7 +31,7 @@ func (a *AllwiseInputSchema) ToMastercat() ParquetMastercat {
 	ipix := int64(0)
 	catalog := "allwise"
 	return ParquetMastercat{
-		ID:   a.Designation,
+		ID:   a.Source_id,
 		Ipix: &ipix,
 		Ra:   a.Ra,
 		Dec:  a.Dec,
@@ -41,7 +41,7 @@ func (a *AllwiseInputSchema) ToMastercat() ParquetMastercat {
 
 func (a *AllwiseInputSchema) ToMetadata() AllwiseMetadata {
 	return AllwiseMetadata{
-		Designation:  a.Designation,
+		Source_id:  a.Source_id,
 		W1mpro:       a.W1mpro,
 		W1sigmpro:    a.W1sigmpro,
 		W2mpro:       a.W2mpro,
@@ -61,8 +61,8 @@ func (a *AllwiseInputSchema) ToMetadata() AllwiseMetadata {
 
 func (a *AllwiseInputSchema) SetField(name string, val any) {
 	switch n := strings.ToLower(name); n {
-	case "designation":
-		a.Designation = val.(*string)
+	case "source_id":
+		a.Source_id = val.(*string)
 	case "ra":
 		a.Ra = val.(*float64)
 	case "dec":

--- a/service/internal/repository/input_schema_test.go
+++ b/service/internal/repository/input_schema_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAllwiseInputSchemaToMastercat(t *testing.T) {
-	designation := "designation"
+	source_id := "source_id"
 	ra := 0.0
 	dec := 0.0
 	catalog := "allwise"
@@ -20,7 +20,7 @@ func TestAllwiseInputSchemaToMastercat(t *testing.T) {
 	}
 	require.Implements(t, (*InputSchema)(nil), a)
 	expected := ParquetMastercat{
-		ID:   &designation,
+		ID:   &source_id,
 		Ra:   &ra,
 		Dec:  &dec,
 		Cat:  &catalog,
@@ -31,7 +31,7 @@ func TestAllwiseInputSchemaToMastercat(t *testing.T) {
 }
 
 func TestAllwiseInputSchema_SetField(t *testing.T) {
-	design := "designation"
+	source := "source_id"
 	ra := float64(0.0)
 	dec := float64(0.0)
 	tests := []struct {
@@ -39,7 +39,7 @@ func TestAllwiseInputSchema_SetField(t *testing.T) {
 		name string
 		val  any
 	}{
-		{"Designation", &design},
+		{"Source_id", &source},
 		{"Ra", &ra},
 		{"Dec", &dec},
 	}

--- a/service/internal/repository/metadata.go
+++ b/service/internal/repository/metadata.go
@@ -3,7 +3,7 @@ package repository
 import "database/sql"
 
 type AllwiseMetadata struct {
-	Designation  *string  `parquet:"name=designation, type=BYTE_ARRAY"`
+	Source_id  *string  `parquet:"name=source_id, type=BYTE_ARRAY"`
 	W1mpro       *float64 `parquet:"name=w1mpro, type=DOUBLE"`
 	W1sigmpro    *float64 `parquet:"name=w1sigmpro, type=DOUBLE"`
 	W2mpro       *float64 `parquet:"name=w2mpro, type=DOUBLE"`
@@ -22,7 +22,7 @@ type AllwiseMetadata struct {
 
 func (m AllwiseMetadata) ToAllwise() Allwise {
 	return Allwise{
-		ID:         *m.Designation,
+		ID:         *m.Source_id,
 		W1mpro:     sql.NullFloat64{Float64: *m.W1mpro, Valid: m.W1mpro != nil},
 		W1sigmpro:  sql.NullFloat64{Float64: *m.W1sigmpro, Valid: m.W1sigmpro != nil},
 		W2mpro:     sql.NullFloat64{Float64: *m.W2mpro, Valid: m.W2mpro != nil},
@@ -42,7 +42,7 @@ func (m AllwiseMetadata) ToAllwise() Allwise {
 
 func (m AllwiseMetadata) ToInsertParams() InsertAllwiseParams {
 	return InsertAllwiseParams{
-		ID:         *m.Designation,
+		ID:         *m.Source_id,
 		W1mpro:     sql.NullFloat64{Float64: nilOr0(m.W1mpro), Valid: m.W1mpro != nil},
 		W1sigmpro:  sql.NullFloat64{Float64: nilOr0(m.W1sigmpro), Valid: m.W1sigmpro != nil},
 		W2mpro:     sql.NullFloat64{Float64: nilOr0(m.W2mpro), Valid: m.W2mpro != nil},

--- a/service/internal/search/conesearch/configuration.go
+++ b/service/internal/search/conesearch/configuration.go
@@ -35,7 +35,7 @@ func WithResolution(res int) ConesearchOption {
 
 func WithCatalogs(catalogs []repository.Catalog) ConesearchOption {
 	return func(service *ConesearchService) error {
-		allowed := []string{"vlass", "wise", "ztf"}
+		allowed := []string{"vlass", "allwise", "ztf"}
 		for i := range catalogs {
 			catName := strings.ToLower(catalogs[i].Name)
 			if !slices.Contains(allowed, catName) {

--- a/service/internal/search/conesearch/validation.go
+++ b/service/internal/search/conesearch/validation.go
@@ -75,7 +75,7 @@ func ValidateNneighbor(nneighbor int) error {
 }
 
 func ValidateCatalog(catalog string) error {
-	available := []string{"vlass", "ztf", "wise", "all"}
+	available := []string{"vlass", "ztf", "allwise", "all"}
 	cat := strings.ToLower(catalog)
 	if !slices.Contains(available, cat) {
 		err := NewValidationError("Catalog not available", catalog, "catalog")


### PR DESCRIPTION
This pull request includes several changes primarily focused on renaming the `Designation` field to `Source_id` in various files and functions, as well as updating the distance calculation method in the `knn` package.

The ALLWISE catalog seems to have duplicated `designation` values. This PR updates the identifier field to `source_id`.

Field renaming:

* [`service/internal/catalog_indexer/indexer/metadata/allwise/allwise_actor_test.go`](diffhunk://#diff-e1ca0220d92f6e018a21cb3323e2badd64858ea311b669b053b5009ae5149898L19-R25): Renamed `Designation` to `Source_id` in the `TestStart` function. [[1]](diffhunk://#diff-e1ca0220d92f6e018a21cb3323e2badd64858ea311b669b053b5009ae5149898L19-R25) [[2]](diffhunk://#diff-e1ca0220d92f6e018a21cb3323e2badd64858ea311b669b053b5009ae5149898L42-R42)
* [`service/internal/repository/input_schema.go`](diffhunk://#diff-f07eafd4b269a181053075cfd8879df3f8b7a1c8f9fa7093f8ed2e3b6c5d11d2L11-R11): Updated `AllwiseInputSchema` and related methods to use `Source_id` instead of `Designation`. [[1]](diffhunk://#diff-f07eafd4b269a181053075cfd8879df3f8b7a1c8f9fa7093f8ed2e3b6c5d11d2L11-R11) [[2]](diffhunk://#diff-f07eafd4b269a181053075cfd8879df3f8b7a1c8f9fa7093f8ed2e3b6c5d11d2L34-R34) [[3]](diffhunk://#diff-f07eafd4b269a181053075cfd8879df3f8b7a1c8f9fa7093f8ed2e3b6c5d11d2L44-R44) [[4]](diffhunk://#diff-f07eafd4b269a181053075cfd8879df3f8b7a1c8f9fa7093f8ed2e3b6c5d11d2L64-R65)
* [`service/internal/repository/metadata.go`](diffhunk://#diff-5a3fe72bd4e454d2d5f9b0f316ea8aa341ad28f1871d3f5aa4e74a58cd526978L6-R6): Modified `AllwiseMetadata` to replace `Designation` with `Source_id`. [[1]](diffhunk://#diff-5a3fe72bd4e454d2d5f9b0f316ea8aa341ad28f1871d3f5aa4e74a58cd526978L6-R6) [[2]](diffhunk://#diff-5a3fe72bd4e454d2d5f9b0f316ea8aa341ad28f1871d3f5aa4e74a58cd526978L25-R25) [[3]](diffhunk://#diff-5a3fe72bd4e454d2d5f9b0f316ea8aa341ad28f1871d3f5aa4e74a58cd526978L45-R45)
* [`service/internal/catalog_indexer/reader/parquet/parquet_reader.go`](diffhunk://#diff-e798ad247b3902c9a0eb70b529b0e48790d1f30863d546cd1e168e7dc77f820eL161-R161): Changed `SetField` calls to use `Source_id` instead of `Designation` for the "allwise" catalog.
* [`service/internal/catalog_indexer/writer/sqlite/sqlite_writer_test.go`](diffhunk://#diff-a969f4f7dbe00e7242ad1ebbc3d41e67ea23247e6221ebad261fe2b27d9d9827L55-R61): Updated the `TestStart_Allwise` function to use `Source_id` instead of `Designation`.
* [`service/internal/repository/input_schema_test.go`](diffhunk://#diff-c4094a907a427f02691d7613166aa05c39a5bb414de9c214746f695d414450ecL11-R11): Adjusted tests to reflect the renaming of `Designation` to `Source_id`. [[1]](diffhunk://#diff-c4094a907a427f02691d7613166aa05c39a5bb414de9c214746f695d414450ecL11-R11) [[2]](diffhunk://#diff-c4094a907a427f02691d7613166aa05c39a5bb414de9c214746f695d414450ecL23-R23) [[3]](diffhunk://#diff-c4094a907a427f02691d7613166aa05c39a5bb414de9c214746f695d414450ecL34-R42)

Distance calculation update:

* [`service/internal/search/knn/knn.go`](diffhunk://#diff-818c2f4d9c85ec2107063cd92a79b35ece20d60a3bdab90e5259ae249b3b14fbL38-R39): Replaced the `euclideanDistance` function with `haversineDistance` for more accurate distance calculations on a sphere. [[1]](diffhunk://#diff-818c2f4d9c85ec2107063cd92a79b35ece20d60a3bdab90e5259ae249b3b14fbL38-R39) [[2]](diffhunk://#diff-818c2f4d9c85ec2107063cd92a79b35ece20d60a3bdab90e5259ae249b3b14fbR55-R83)

Catalog validation:

* [`service/internal/search/conesearch/configuration.go`](diffhunk://#diff-39f184396426855c7bbca6c8fd61dd8c87bb20ab18cffb5e5d2fa28cffa07aceL38-R38): Updated the list of allowed catalogs to include "allwise".
* [`service/internal/search/conesearch/validation.go`](diffhunk://#diff-d327bb9d4ddd0691e54cfe906ed174d72bb7a6fec787fa77df1e13bbbf03824bL78-R78): Modified the catalog validation to recognize "allwise" as an available catalog.