### PR TITLE
feat: add env variable to disable logging

### DIFF
--- a/service/internal/http_service/server.go
+++ b/service/internal/http_service/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/dirodriguezm/xmatch/service/internal/search/conesearch"
 	"github.com/dirodriguezm/xmatch/service/internal/search/metadata"
@@ -34,7 +35,11 @@ func NewHttpServer(
 }
 
 func (server *HttpServer) SetupServer() *gin.Engine {
-	r := gin.Default()
+	r := gin.New()
+	r.Use(gin.Recovery())
+	if os.Getenv("USE_LOGGER") != "" {
+		r.Use(gin.Logger())
+	}
 	r.GET("/ping", func(c *gin.Context) {
 		c.String(http.StatusOK, "pong")
 	})


### PR DESCRIPTION
Add `USE_LOGGER` env variable to enable logging.

`USE_LOGGER=true go run cmd/main.go server` 