### PR TITLE
feat: query allwise metadata using list of ids

### DIFF
--- a/service/internal/db/query.sql
+++ b/service/internal/db/query.sql
@@ -45,6 +45,11 @@ SELECT *
 FROM allwise
 WHERE id = ?;
 
+-- name: BulkGetAllwise :many
+SELECT *
+FROM allwise
+WHERE id IN (sqlc.slice(id));
+
 -- name: RemoveAllObjects :exec
 DELETE FROM mastercat;
 

--- a/service/internal/search/conesearch/conesearch.go
+++ b/service/internal/search/conesearch/conesearch.go
@@ -26,6 +26,7 @@ type Repository interface {
 	GetAllwise(context.Context, string) (repository.Allwise, error)
 	BulkInsertAllwise(context.Context, *sql.DB, []repository.InsertAllwiseParams) error
 	RemoveAllObjects(context.Context) error
+	BulkGetAllwise(context.Context, []string) ([]repository.Allwise, error)
 }
 
 type ConesearchService struct {

--- a/service/internal/search/metadata/metadata_service_test.go
+++ b/service/internal/search/metadata/metadata_service_test.go
@@ -49,7 +49,24 @@ func TestMetadata_FindByID(t *testing.T) {
 	require.Equal(t, "allwise1", *result.(repository.AllwiseMetadata).Source_id)
 }
 
-func TestMetadata_EmptyResult(t *testing.T) {
+func TestMetadata_BulkFindByID(t *testing.T) {
+	repo := &mocks.Repository{}
+	repo.On("BulkGetAllwise", mock.Anything, []string{"allwise1", "allwise2"}).Return([]repository.Allwise{{ID: "allwise1"}, {ID: "allwise2"}}, nil)
+
+	m := &MetadataService{
+		repository: repo,
+	}
+
+	result, err := m.BulkFindByID(context.TODO(), []string{"allwise1", "allwise2"}, "allwise")
+	require.Nil(t, err)
+	repo.AssertExpectations(t)
+	expectedIds := []string{"allwise1", "allwise2"}
+	for i := 0; i < len(result.([]repository.AllwiseMetadata)); i++ {
+		require.Equal(t, expectedIds[i], *result.([]repository.AllwiseMetadata)[i].Source_id)
+	}
+}
+
+func TestMetadata_Bulk_EmptyResult(t *testing.T) {
 	repo := &mocks.Repository{}
 
 	repo.

--- a/service/mocks/Repository.go
+++ b/service/mocks/Repository.go
@@ -24,6 +24,65 @@ func (_m *Repository) EXPECT() *Repository_Expecter {
 	return &Repository_Expecter{mock: &_m.Mock}
 }
 
+// BulkGetAllwise provides a mock function with given fields: _a0, _a1
+func (_m *Repository) BulkGetAllwise(_a0 context.Context, _a1 []string) ([]repository.Allwise, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BulkGetAllwise")
+	}
+
+	var r0 []repository.Allwise
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]repository.Allwise, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []string) []repository.Allwise); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]repository.Allwise)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Repository_BulkGetAllwise_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BulkGetAllwise'
+type Repository_BulkGetAllwise_Call struct {
+	*mock.Call
+}
+
+// BulkGetAllwise is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 []string
+func (_e *Repository_Expecter) BulkGetAllwise(_a0 interface{}, _a1 interface{}) *Repository_BulkGetAllwise_Call {
+	return &Repository_BulkGetAllwise_Call{Call: _e.mock.On("BulkGetAllwise", _a0, _a1)}
+}
+
+func (_c *Repository_BulkGetAllwise_Call) Run(run func(_a0 context.Context, _a1 []string)) *Repository_BulkGetAllwise_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *Repository_BulkGetAllwise_Call) Return(_a0 []repository.Allwise, _a1 error) *Repository_BulkGetAllwise_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Repository_BulkGetAllwise_Call) RunAndReturn(run func(context.Context, []string) ([]repository.Allwise, error)) *Repository_BulkGetAllwise_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BulkInsertAllwise provides a mock function with given fields: _a0, _a1, _a2
 func (_m *Repository) BulkInsertAllwise(_a0 context.Context, _a1 *sql.DB, _a2 []repository.InsertAllwiseParams) error {
 	ret := _m.Called(_a0, _a1, _a2)


### PR DESCRIPTION
# Add bulk metadata retrieval endpoint

Implements a new `/v1/bulk-metadata` endpoint that allows retrieving metadata for multiple object IDs in a single request. This enhancement improves efficiency when clients need to fetch information for multiple astronomical objects.

Key changes:
- Added SQL query `BulkGetAllwise` to retrieve multiple Allwise records by ID
- Implemented `BulkFindByID` method in the metadata service
- Created new HTTP handler `metadataBulkHandler` with validation
- Added input validation to prevent SQL injection
- Added comprehensive test coverage

This addition follows the same pattern used for the existing bulk conesearch endpoint, providing a consistent API experience. The implementation includes robust validation to ensure secure handling of user input.