### PR TITLE
fix: bulk conesearch performance

### DIFF
--- a/service/config.yaml
+++ b/service/config.yaml
@@ -44,3 +44,4 @@ service:
   database:
     # a path to the SQLite database file
     url: "file:dev.db"
+  bulk_chunk_size: 500

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -59,7 +59,8 @@ type WriterConfig struct {
 }
 
 type ServiceConfig struct {
-	Database *DatabaseConfig `yaml:"database"`
+	Database      *DatabaseConfig `yaml:"database"`
+	BulkChunkSize int             `yaml:"bulk_chunk_size"`
 }
 
 type DatabaseConfig struct {

--- a/service/internal/di/service_container.go
+++ b/service/internal/di/service_container.go
@@ -103,8 +103,9 @@ func BuildServiceContainer() container.Container {
 	ctr.Singleton(func(
 		conesearchService *conesearch.ConesearchService,
 		metadataService *metadata.MetadataService,
+		config *config.Config,
 	) *httpservice.HttpServer {
-		server, err := httpservice.NewHttpServer(conesearchService, metadataService)
+		server, err := httpservice.NewHttpServer(conesearchService, metadataService, config.Service)
 		if err != nil {
 			panic(fmt.Errorf("Could not register HttpServer: %w", err))
 		}

--- a/service/internal/search/conesearch/conesearch_integration_test.go
+++ b/service/internal/search/conesearch/conesearch_integration_test.go
@@ -156,7 +156,7 @@ func TestBulkConesearch(t *testing.T) {
 
 	// test bulk conesearch
 	for _, tc := range testCases {
-		result, err := service.BulkConesearch(tc.ra, tc.dec, tc.radius, tc.nneighbor, "all")
+		result, err := service.BulkConesearch(tc.ra, tc.dec, tc.radius, tc.nneighbor, "all", 1)
 		if err != nil {
 			t.Error(err)
 		}

--- a/service/internal/search/conesearch/conesearch_test.go
+++ b/service/internal/search/conesearch/conesearch_test.go
@@ -103,7 +103,7 @@ func TestBulkConesearch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result, err := service.BulkConesearch(tc.ra, tc.dec, tc.radius, tc.nneighbor, "all")
+		result, err := service.BulkConesearch(tc.ra, tc.dec, tc.radius, tc.nneighbor, "all", 2)
 		require.NoError(t, err)
 		repo.AssertExpectations(t)
 


### PR DESCRIPTION
This PR improves the performance of the bulk conesearch operation by implementing parallel processing with goroutines. The key changes are:

1. **Added configuration parameter**: 
   - Introduced `bulk_chunk_size` (default: 500) in the service configuration
   - Modified relevant config structs and parsers to support this new parameter

2. **Enhanced bulk conesearch implementation**:
   - Redesigned `BulkConesearch` function to process requests in parallel chunks
   - Implemented goroutines to handle each chunk concurrently
   - Added synchronization with WaitGroup and channels for results and errors
   - Improved memory usage by processing and collecting results incrementally

3. **Updated dependencies**:
   - Added config parameter to HttpServer constructor
   - Added config parameter to conesearch bulk handler
   - Updated tests to work with the new parameter

This change significantly improves performance for bulk operations with large datasets by breaking the work into manageable chunks and processing them concurrently rather than sequentially.