### PR TITLE
feat: add parameter to get metadata from a conesearch request

### DIFF
--- a/service/internal/db/query.sql
+++ b/service/internal/db/query.sql
@@ -58,3 +58,10 @@ DELETE FROM allwise;
 
 -- name: RemoveAllCatalogs :exec
 DELETE FROM catalogs;
+
+-- name: GetAllwiseFromPixels :many
+SELECT allwise.*, mastercat.ra, mastercat.dec
+FROM allwise 
+JOIN mastercat ON mastercat.id = allwise.id
+WHERE mastercat.ipix IN (sqlc.slice(ipix));
+

--- a/service/internal/repository/metadata.go
+++ b/service/internal/repository/metadata.go
@@ -138,6 +138,83 @@ func (m AllwiseMetadata) ToInsertParams() InsertAllwiseParams {
 	}
 }
 
+func (m GetAllwiseFromPixelsRow) ToAllwiseMetadata() AllwiseMetadata {
+	defaultVal := -9999.0
+	w1mpro := m.W1mpro.Float64
+	if !m.W1mpro.Valid {
+		w1mpro = defaultVal
+	}
+	w1sigmpro := m.W1sigmpro.Float64
+	if !m.W1sigmpro.Valid {
+		w1sigmpro = defaultVal
+	}
+	w2mpro := m.W2mpro.Float64
+	if !m.W2mpro.Valid {
+		w2mpro = defaultVal
+	}
+	w2sigmpro := m.W2sigmpro.Float64
+	if !m.W2sigmpro.Valid {
+		w2sigmpro = defaultVal
+	}
+	w3mpro := m.W3mpro.Float64
+	if !m.W3mpro.Valid {
+		w3mpro = defaultVal
+	}
+	w3sigmpro := m.W3sigmpro.Float64
+	if !m.W3sigmpro.Valid {
+		w3sigmpro = defaultVal
+	}
+	w4mpro := m.W4mpro.Float64
+	if !m.W4mpro.Valid {
+		w4mpro = defaultVal
+	}
+	w4sigmpro := m.W4sigmpro.Float64
+	if !m.W4sigmpro.Valid {
+		w4sigmpro = defaultVal
+	}
+	jM2mass := m.JM2mass.Float64
+	if !m.JM2mass.Valid {
+		jM2mass = defaultVal
+	}
+	jMsig2mass := m.JMsig2mass.Float64
+	if !m.JMsig2mass.Valid {
+		jMsig2mass = defaultVal
+	}
+	hM2mass := m.HM2mass.Float64
+	if !m.HM2mass.Valid {
+		hM2mass = defaultVal
+	}
+	hMsig2mass := m.HMsig2mass.Float64
+	if !m.HMsig2mass.Valid {
+		hMsig2mass = defaultVal
+	}
+	kM2mass := m.KM2mass.Float64
+	if !m.KM2mass.Valid {
+		kM2mass = defaultVal
+	}
+	kMsig2mass := m.KMsig2mass.Float64
+	if !m.KMsig2mass.Valid {
+		kMsig2mass = defaultVal
+	}
+	return AllwiseMetadata{
+		Source_id:    &m.ID,
+		W1mpro:       &w1mpro,
+		W1sigmpro:    &w1sigmpro,
+		W2mpro:       &w2mpro,
+		W2sigmpro:    &w2sigmpro,
+		W3mpro:       &w3mpro,
+		W3sigmpro:    &w3sigmpro,
+		W4mpro:       &w4mpro,
+		W4sigmpro:    &w4sigmpro,
+		J_m_2mass:    &jM2mass,
+		H_m_2mass:    &hM2mass,
+		K_m_2mass:    &kM2mass,
+		J_msig_2mass: &jMsig2mass,
+		H_msig_2mass: &hMsig2mass,
+		K_msig_2mass: &kMsig2mass,
+	}
+}
+
 func nilOr0(f *float64) float64 {
 	if f == nil {
 		return 0

--- a/service/internal/search/conesearch/conesearch_test.go
+++ b/service/internal/search/conesearch/conesearch_test.go
@@ -114,6 +114,25 @@ func TestBulkConesearch(t *testing.T) {
 	}
 }
 
+func TestConesearch_WithMetadata(t *testing.T) {
+	objects := []repository.GetAllwiseFromPixelsRow{
+		{ID: "A", Ra: 1, Dec: 1},
+		{ID: "B", Ra: 10, Dec: 10},
+	}
+	repo := &mocks.Repository{}
+	repo.On("GetAllwiseFromPixels", mock.Anything, mock.Anything).Return(objects, nil)
+	catalogs := []repository.Catalog{{Name: "allwise", Nside: 18}}
+	service, err := NewConesearchService(WithScheme(healpix.Nest), WithRepository(repo), WithCatalogs(catalogs))
+	require.NoError(t, err)
+
+	result, err := service.FindMetadataByConesearch(1, 1, 1, 1, "allwise")
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+
+	require.Len(t, result, 1)
+	require.Equal(t, *result.([]repository.AllwiseMetadata)[0].Source_id, "A")
+}
+
 func FuzzConesearch(f *testing.F) {
 	objects := []repository.Mastercat{
 		{ID: "A", Ra: 1, Dec: 1, Cat: "vlass"},

--- a/service/mocks/Repository.go
+++ b/service/mocks/Repository.go
@@ -353,6 +353,65 @@ func (_c *Repository_GetAllwise_Call) RunAndReturn(run func(context.Context, str
 	return _c
 }
 
+// GetAllwiseFromPixels provides a mock function with given fields: _a0, _a1
+func (_m *Repository) GetAllwiseFromPixels(_a0 context.Context, _a1 []int64) ([]repository.GetAllwiseFromPixelsRow, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllwiseFromPixels")
+	}
+
+	var r0 []repository.GetAllwiseFromPixelsRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []int64) ([]repository.GetAllwiseFromPixelsRow, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []int64) []repository.GetAllwiseFromPixelsRow); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]repository.GetAllwiseFromPixelsRow)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []int64) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Repository_GetAllwiseFromPixels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllwiseFromPixels'
+type Repository_GetAllwiseFromPixels_Call struct {
+	*mock.Call
+}
+
+// GetAllwiseFromPixels is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 []int64
+func (_e *Repository_Expecter) GetAllwiseFromPixels(_a0 interface{}, _a1 interface{}) *Repository_GetAllwiseFromPixels_Call {
+	return &Repository_GetAllwiseFromPixels_Call{Call: _e.mock.On("GetAllwiseFromPixels", _a0, _a1)}
+}
+
+func (_c *Repository_GetAllwiseFromPixels_Call) Run(run func(_a0 context.Context, _a1 []int64)) *Repository_GetAllwiseFromPixels_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]int64))
+	})
+	return _c
+}
+
+func (_c *Repository_GetAllwiseFromPixels_Call) Return(_a0 []repository.GetAllwiseFromPixelsRow, _a1 error) *Repository_GetAllwiseFromPixels_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Repository_GetAllwiseFromPixels_Call) RunAndReturn(run func(context.Context, []int64) ([]repository.GetAllwiseFromPixelsRow, error)) *Repository_GetAllwiseFromPixels_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCatalogs provides a mock function with given fields: _a0
 func (_m *Repository) GetCatalogs(_a0 context.Context) ([]repository.Catalog, error) {
 	ret := _m.Called(_a0)


### PR DESCRIPTION
# Add metadata search support to conesearch functionality

This PR adds the ability to search for and retrieve metadata from the AllWise catalog using the existing conesearch functionality. The implementation includes:

## Key Changes

1. Added a new SQL query `GetAllwiseFromPixels` to fetch AllWise catalog data based on HEALPix pixel IDs
2. Created a new method `FindMetadataByConesearch` in the conesearch service
3. Extended the KNN search to support AllWise metadata objects
4. Added a new `getMetadata` query parameter to the conesearch HTTP endpoint
5. Enhanced the `isEmptyResult` function to handle both Mastercat and AllwiseMetadata result types
6. Added appropriate tests for the new functionality

## Implementation Details

- The metadata search leverages the existing HEALPix-based spatial indexing
- Results include full AllWise catalog metadata along with RA/Dec coordinates
- A conversion method was added to transform SQL query results into the AllwiseMetadata type
- Added comprehensive tests for the new functionality at both unit and integration levels

## Usage

Users can now retrieve AllWise metadata by setting `getMetadata=true` in their conesearch requests, making it possible to get both positional data and astronomical measurements in a single query.