### PR TITLE
feat: add partition writer

### DIFF
--- a/service/internal/catalog_indexer/indexer/mastercat/indexer_actor_test.go
+++ b/service/internal/catalog_indexer/indexer/mastercat/indexer_actor_test.go
@@ -52,8 +52,11 @@ func (t *TestSchema) GetCoordinates() (float64, float64) {
 	return t.Ra, t.Dec
 }
 
-// implement the interface
 func (t *TestSchema) SetField(name string, val interface{}) {}
+
+func (t *TestSchema) GetId() string {
+	return t.ID
+}
 
 func TestIndexActor(t *testing.T) {
 	inbox := make(chan reader.ReaderResult)

--- a/service/internal/catalog_indexer/indexer/metadata/metadata_actor_test.go
+++ b/service/internal/catalog_indexer/indexer/metadata/metadata_actor_test.go
@@ -43,6 +43,10 @@ func (t TestInputSchema) ToMastercat(ipix int64) repository.ParquetMastercat {
 
 func (t TestInputSchema) SetField(string, any) {}
 
+func (t TestInputSchema) GetId() string {
+	return t.Id
+}
+
 func TestStart(t *testing.T) {
 	inbox := make(chan reader.ReaderResult)
 	outbox := make(chan writer.WriterInput[any])

--- a/service/internal/catalog_indexer/reader/base_reader.go
+++ b/service/internal/catalog_indexer/reader/base_reader.go
@@ -31,6 +31,7 @@ type Reader interface {
 	Start()
 	Read() ([]repository.InputSchema, error)
 	ReadBatch() ([]repository.InputSchema, error)
+	GetOutbox() []chan ReaderResult
 }
 
 type BaseReader struct {
@@ -73,4 +74,8 @@ func (r BaseReader) Start() {
 			}
 		}
 	}()
+}
+
+func (r BaseReader) GetOutbox() []chan ReaderResult {
+	return r.Outbox
 }

--- a/service/internal/catalog_indexer/reader/csv/test_helpers.go
+++ b/service/internal/catalog_indexer/reader/csv/test_helpers.go
@@ -144,3 +144,7 @@ func (t *TestSchema) SetField(name string, val interface{}) {
 		t.Oid = val.(string)
 	}
 }
+
+func (t *TestSchema) GetId() string {
+	return t.Oid
+}

--- a/service/internal/catalog_indexer/reader/parquet/test_helpers.go
+++ b/service/internal/catalog_indexer/reader/parquet/test_helpers.go
@@ -64,6 +64,10 @@ func (t *TestInputSchema) SetField(name string, val interface{}) {
 	}
 }
 
+func (t *TestInputSchema) GetId() string {
+	return t.Oid
+}
+
 type ReaderBuilder[T any] struct {
 	ReaderConfig  *config.ReaderConfig
 	t             *testing.T

--- a/service/internal/catalog_indexer/writer/base_writer.go
+++ b/service/internal/catalog_indexer/writer/base_writer.go
@@ -32,7 +32,7 @@ type Writer[T any] interface {
 
 type BaseWriter[T any] struct {
 	Writer       Writer[T]
-	DoneChannel  chan bool
+	DoneChannel  chan struct{}
 	InboxChannel chan WriterInput[T]
 }
 

--- a/service/internal/catalog_indexer/writer/parquet/parquet_writer.go
+++ b/service/internal/catalog_indexer/writer/parquet/parquet_writer.go
@@ -34,7 +34,7 @@ type ParquetWriter[T any] struct {
 
 func NewParquetWriter[T any](
 	inbox chan writer.WriterInput[T],
-	done chan bool,
+	done chan struct{},
 	cfg *config.WriterConfig,
 ) (*ParquetWriter[T], error) {
 	slog.Debug("Creating new ParquetWriter")
@@ -96,6 +96,6 @@ func (w *ParquetWriter[T]) Stop() {
 	if err := w.pfile.Close(); err != nil {
 		panic(fmt.Errorf("ParquetWriter could not close parquet file %w", err))
 	}
-	w.DoneChannel <- true
+	w.DoneChannel <- struct{}{}
 	close(w.DoneChannel)
 }

--- a/service/internal/catalog_indexer/writer/parquet/parquet_writer_integration_test.go
+++ b/service/internal/catalog_indexer/writer/parquet/parquet_writer_integration_test.go
@@ -89,8 +89,7 @@ func TestActor(t *testing.T) {
 	decs := []float64{1, 2}
 	ipixs := []int64{1, 2}
 	cat := "vlass"
-	w.(*parquet_writer.ParquetWriter[any]).
-		InboxChannel <- writer.WriterInput[any]{
+	w.(*parquet_writer.ParquetWriter[any]).InboxChannel <- writer.WriterInput[any]{
 		Rows: []any{
 			repository.ParquetMastercat{ID: &oids[0], Ipix: &ipixs[0], Ra: &ras[0], Dec: &decs[0], Cat: &cat},
 			repository.ParquetMastercat{ID: &oids[1], Ipix: &ipixs[1], Ra: &ras[1], Dec: &decs[1], Cat: &cat},

--- a/service/internal/catalog_indexer/writer/parquet/test_helper.go
+++ b/service/internal/catalog_indexer/writer/parquet/test_helper.go
@@ -32,7 +32,7 @@ type ParquetWriterBuilder[T any] struct {
 
 	cfg   *config.WriterConfig
 	input chan writer.WriterInput[T]
-	done  chan bool
+	done  chan struct{}
 }
 
 func AWriter[T any](t *testing.T) *ParquetWriterBuilder[T] {
@@ -42,7 +42,7 @@ func AWriter[T any](t *testing.T) *ParquetWriterBuilder[T] {
 		t:     t,
 		cfg:   &config.WriterConfig{OutputFile: "test.parquet", Schema: config.TestSchema},
 		input: make(chan writer.WriterInput[T]),
-		done:  make(chan bool),
+		done:  make(chan struct{}),
 	}
 }
 

--- a/service/internal/catalog_indexer/writer/sqlite/sqlite_writer.go
+++ b/service/internal/catalog_indexer/writer/sqlite/sqlite_writer.go
@@ -40,7 +40,7 @@ type SqliteWriter[T any] struct {
 func NewSqliteWriter[T any](
 	repository conesearch.Repository,
 	ch chan writer.WriterInput[T],
-	done chan bool,
+	done chan struct{},
 	ctx context.Context,
 	src *source.Source,
 ) *SqliteWriter[T] {
@@ -79,7 +79,7 @@ func (w *SqliteWriter[T]) Receive(msg writer.WriterInput[T]) {
 }
 
 func (w *SqliteWriter[T]) Stop() {
-	w.DoneChannel <- true
+	w.DoneChannel <- struct{}{}
 }
 
 func insertData[T any](repo conesearch.Repository, ctx context.Context, db *sql.DB, params []T) error {

--- a/service/internal/catalog_indexer/writer/sqlite/sqlite_writer_integration_test.go
+++ b/service/internal/catalog_indexer/writer/sqlite/sqlite_writer_integration_test.go
@@ -115,7 +115,7 @@ func TestActor(t *testing.T) {
 	err := ctr.Resolve(&repo)
 	require.NoError(t, err)
 	ctx := context.Background()
-	done := make(chan bool)
+	done := make(chan struct{})
 	src := source.ASource(t).WithUrl(fmt.Sprintf("files:%s", t.TempDir())).Build()
 	w := sqlite_writer.NewSqliteWriter(repo, ch, done, ctx, src)
 

--- a/service/internal/catalog_indexer/writer/sqlite/sqlite_writer_test.go
+++ b/service/internal/catalog_indexer/writer/sqlite/sqlite_writer_test.go
@@ -51,7 +51,7 @@ func TestStart_Mastercat(t *testing.T) {
 		mock.Anything,
 		[]repository.InsertObjectParams{params.(repository.InsertObjectParams)},
 	).Return(nil)
-	w := NewSqliteWriter(repo, make(chan writer.WriterInput[repository.ParquetMastercat]), make(chan bool), context.Background(), src)
+	w := NewSqliteWriter(repo, make(chan writer.WriterInput[repository.ParquetMastercat]), make(chan struct{}), context.Background(), src)
 
 	w.Start()
 	w.BaseWriter.InboxChannel <- writer.WriterInput[repository.ParquetMastercat]{
@@ -90,7 +90,7 @@ func TestStart_Allwise(t *testing.T) {
 	w := NewSqliteWriter(
 		repo,
 		make(chan writer.WriterInput[repository.AllwiseMetadata]),
-		make(chan bool),
+		make(chan struct{}),
 		context.Background(),
 		src,
 	)

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -27,17 +27,22 @@ import (
 type Config struct {
 	CatalogIndexer *CatalogIndexerConfig `yaml:"catalog_indexer"`
 	Service        *ServiceConfig        `yaml:"service"`
+	Preprocessor   *PreprocessorConfig   `yaml:"preprocessor"`
 }
 
 type CatalogIndexerConfig struct {
-	Database        *DatabaseConfig `yaml:"database"`
-	Source          *SourceConfig   `yaml:"source"`
-	Reader          *ReaderConfig   `yaml:"reader"`
-	Indexer         *IndexerConfig  `yaml:"indexer"`
-	PartitionWriter *WriterConfig   `yaml:"partition_writer"`
-	ReducerWriter   *WriterConfig   `yaml:"reducer_writer"`
-	IndexerWriter   *WriterConfig   `yaml:"indexer_writer"`
-	MetadataWriter  *WriterConfig   `yaml:"metadata_writer"`
+	Database       *DatabaseConfig `yaml:"database"`
+	Source         *SourceConfig   `yaml:"source"`
+	Reader         *ReaderConfig   `yaml:"reader"`
+	Indexer        *IndexerConfig  `yaml:"indexer"`
+	IndexerWriter  *WriterConfig   `yaml:"indexer_writer"`
+	MetadataWriter *WriterConfig   `yaml:"metadata_writer"`
+}
+
+type PreprocessorConfig struct {
+	Source          *SourceConfig          `yaml:"source"`
+	Reader          *ReaderConfig          `yaml:"reader"`
+	PartitionWriter *PartitionWriterConfig `yaml:"partition_writer"`
 }
 
 type SourceConfig struct {
@@ -79,6 +84,16 @@ type WriterConfig struct {
 	// parquet config
 	OutputFile string `yaml:"output_file"`
 	Schema     ParquetWriterSchema
+}
+
+type PartitionWriterConfig struct {
+	Schema      ParquetWriterSchema
+	MaxFileSize int `yaml:"max_file_size"`
+
+	// filesystem config
+	NumPartitions   int    `yaml:"num_partitions"`
+	PartitionLevels int    `yaml:"partition_levels"`
+	BaseDir         string `yaml:"base_dir"`
 }
 
 type ServiceConfig struct {

--- a/service/internal/di/indexer_container.go
+++ b/service/internal/di/indexer_container.go
@@ -149,13 +149,13 @@ func BuildIndexerContainer() container.Container {
 		switch cfg.CatalogIndexer.IndexerWriter.Type {
 		case "parquet":
 			cfg.CatalogIndexer.IndexerWriter.Schema = config.MastercatSchema
-			w, err := parquet_writer.NewParquetWriter(writerInput, make(chan bool), cfg.CatalogIndexer.IndexerWriter)
+			w, err := parquet_writer.NewParquetWriter(writerInput, make(chan struct{}), cfg.CatalogIndexer.IndexerWriter)
 			if err != nil {
 				panic(err)
 			}
 			return w
 		case "sqlite":
-			w := sqlite_writer.NewSqliteWriter(repo, writerInput, make(chan bool), context.TODO(), src)
+			w := sqlite_writer.NewSqliteWriter(repo, writerInput, make(chan struct{}), context.TODO(), src)
 			return w
 		default:
 			slog.Error("Writer type not allowed", "type", cfg.CatalogIndexer.IndexerWriter.Type)
@@ -181,47 +181,19 @@ func BuildIndexerContainer() container.Container {
 			default:
 				panic("Unknown catalog name")
 			}
-			w, err := parquet_writer.NewParquetWriter(writerInputMetadata, make(chan bool), cfg.CatalogIndexer.MetadataWriter)
+			w, err := parquet_writer.NewParquetWriter(writerInputMetadata, make(chan struct{}), cfg.CatalogIndexer.MetadataWriter)
 			if err != nil {
 				panic(err)
 			}
 			return w
 		case "sqlite":
-			w := sqlite_writer.NewSqliteWriter(repo, writerInputMetadata, make(chan bool), context.TODO(), src)
+			w := sqlite_writer.NewSqliteWriter(repo, writerInputMetadata, make(chan struct{}), context.TODO(), src)
 			return w
 		default:
 			slog.Error("Writer type not allowed", "type", cfg.CatalogIndexer.MetadataWriter.Type)
 			panic("Writer type not allowed")
 		}
 	})
-
-	// Register partition writer if is configured
-	// ctr.Singleton(func(cfg *config.Config) indexer.Writer {
-	// 	if cfg.CatalogIndexer.PartitionWriter == nil {
-	// 		return nil
-	// 	}
-	// 	type PartitionSchema struct {
-	// 		ID  string  `parquet:"name=id, type=BYTE_ARRAY"`
-	// 		Ra  float64 `parquet:"name=ra, type=DOUBLE"`
-	// 		Dec float64 `parquet:"name=dec, type=DOUBLE"`
-	// 	}
-	// 	// TODO: Configure partition reader and writer
-	// 	return nil
-	// })
-
-	// Register reducer writer if is configured
-	// ctr.Singleton(func(cfg *config.Config) indexer.Writer {
-	// 	if cfg.CatalogIndexer.ReducerWriter == nil {
-	// 		return nil
-	// 	}
-	// 	type ReducerSchema struct {
-	// 		ID  string  `parquet:"name=id, type=BYTE_ARRAY"`
-	// 		Ra  float64 `parquet:"name=ra, type=DOUBLE"`
-	// 		Dec float64 `parquet:"name=dec, type=DOUBLE"`
-	// 	}
-	// 	// TODO: Configure pre partition reader and writer
-	// 	return nil
-	// })
 
 	return ctr
 }

--- a/service/internal/di/preprocessor_container.go
+++ b/service/internal/di/preprocessor_container.go
@@ -1,0 +1,100 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package di
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/reader"
+	reader_factory "github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/reader/factory"
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/source"
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/writer"
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	partition_writer "github.com/dirodriguezm/xmatch/service/internal/preprocessor/writer"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+	"github.com/golobby/container/v3"
+)
+
+func BuildPreprocessorContainer() container.Container {
+	ctr := container.New()
+
+	ctr.Singleton(func() *config.Config {
+		cfg, err := config.Load()
+		if err != nil {
+			panic(err)
+		}
+		return cfg
+	})
+
+	ctr.Singleton(func() *slog.LevelVar {
+		levels := map[string]slog.Level{
+			"debug": slog.LevelDebug,
+			"info":  slog.LevelInfo,
+			"error": slog.LevelError,
+			"warn":  slog.LevelWarn,
+			"":      slog.LevelInfo,
+		}
+		var programLevel = new(slog.LevelVar)
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: programLevel}))
+		slog.SetDefault(logger)
+		programLevel.Set(levels[os.Getenv("LOG_LEVEL")])
+		return programLevel
+	})
+
+	// Register Source
+	ctr.Singleton(func(cfg *config.Config) *source.Source {
+		src, err := source.NewSource(cfg.Preprocessor.Source)
+		if err != nil {
+			slog.Error("Could not register Source")
+			panic(err)
+		}
+		return src
+	})
+
+	// Register Preprocessor Reader
+	ctr.Singleton(func(src *source.Source, cfg *config.Config) reader.Reader {
+		readerResults := make(chan reader.ReaderResult)
+		r, err := reader_factory.ReaderFactory(src, []chan reader.ReaderResult{readerResults}, cfg.Preprocessor.Reader)
+		if err != nil {
+			panic(fmt.Errorf("Could not register preprocessor reader: %w", err))
+		}
+		return r
+	})
+
+	// Register partition writer if is configured
+	ctr.Singleton(func(cfg *config.Config, src *source.Source, r reader.Reader) *partition_writer.PartitionWriter {
+		switch strings.ToLower(cfg.Preprocessor.Source.CatalogName) {
+		case "allwise":
+			cfg.Preprocessor.PartitionWriter.Schema = config.AllwiseSchema
+		case "test":
+			cfg.Preprocessor.PartitionWriter.Schema = config.TestSchema
+		default:
+			panic(fmt.Errorf("Can't register partition writer: unknown catalog name %s", cfg.CatalogIndexer.Source.CatalogName))
+		}
+
+		inputChan := make(chan writer.WriterInput[repository.InputSchema])
+		doneChan := make(chan struct{})
+		w, err := partition_writer.New(cfg.Preprocessor.PartitionWriter, inputChan, doneChan)
+		if err != nil {
+			panic(fmt.Errorf("Could not register partition writer: %w", err))
+		}
+		return w
+	})
+
+	return ctr
+}

--- a/service/internal/preprocessor/filesystem_manager/filesystem_manager_test.go
+++ b/service/internal/preprocessor/filesystem_manager/filesystem_manager_test.go
@@ -30,8 +30,8 @@ func TestFileSystemManager_TestCreatePartitionDirectory(t *testing.T) {
 	part := partition.Partition{Levels: []int{0, 0}}
 	handler := partition.PartitionHandler{PartitionLevels: 2, NumPartitions: 16}
 	manager := FileSystemManager{
-		handler: handler,
-		baseDir: dir,
+		Handler: handler,
+		BaseDir: dir,
 	}
 
 	_, err := manager.createPartitionDirectory(part)
@@ -41,7 +41,7 @@ func TestFileSystemManager_TestCreatePartitionDirectory(t *testing.T) {
 	require.DirExists(t, path.Join(dir, "00", "00"))
 
 	dir = t.TempDir()
-	manager.baseDir = dir
+	manager.BaseDir = dir
 	part = partition.Partition{Levels: []int{1, 0}}
 
 	_, err = manager.createPartitionDirectory(part)
@@ -51,7 +51,7 @@ func TestFileSystemManager_TestCreatePartitionDirectory(t *testing.T) {
 	require.DirExists(t, path.Join(dir, "01", "00"))
 
 	dir = t.TempDir()
-	manager.baseDir = dir
+	manager.BaseDir = dir
 	part = partition.Partition{Levels: []int{11, 12}}
 
 	_, err = manager.createPartitionDirectory(part)
@@ -69,8 +69,8 @@ func TestFileSystemManager_TestCreatePartitionDirectory_DirectoryAlreadyExistDoe
 	part := partition.Partition{Levels: []int{0, 0}}
 	handler := partition.PartitionHandler{PartitionLevels: 2, NumPartitions: 16}
 	manager := FileSystemManager{
-		handler: handler,
-		baseDir: dir,
+		Handler: handler,
+		BaseDir: dir,
 	}
 
 	_, err = manager.createPartitionDirectory(part)

--- a/service/internal/preprocessor/filesystem_manager/test_helpers.go
+++ b/service/internal/preprocessor/filesystem_manager/test_helpers.go
@@ -48,8 +48,8 @@ func (b *FileSystemManagerBuilder) Build() FileSystemManager {
 	}
 
 	return FileSystemManager{
-		handler: handler,
-		baseDir: b.baseDir,
+		Handler: handler,
+		BaseDir: b.baseDir,
 	}
 }
 

--- a/service/internal/preprocessor/writer/partition_writer.go
+++ b/service/internal/preprocessor/writer/partition_writer.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,8 +14,205 @@
 
 package partition_writer
 
-import filesystemmanager "github.com/dirodriguezm/xmatch/service/internal/preprocessor/filesystem_manager"
+import (
+	"fmt"
+	"os"
+
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/writer"
+	xwaveWriter "github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/writer"
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	filesystemmanager "github.com/dirodriguezm/xmatch/service/internal/preprocessor/filesystem_manager"
+	"github.com/dirodriguezm/xmatch/service/internal/preprocessor/partition"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+	parquetWriter "github.com/xitongsys/parquet-go/writer"
+)
 
 type PartitionWriter struct {
-	fs *filesystemmanager.FileSystemManager
+	*xwaveWriter.BaseWriter[repository.InputSchema]
+	fs            *filesystemmanager.FileSystemManager
+	maxFileSize   int
+	currentWriter *parquetWriter.ParquetWriter
+	currentFile   *os.File
+	dirMap        map[string]int
+	currentDir    string
+	cfg           *config.PartitionWriterConfig
+}
+
+func New(
+	cfg *config.PartitionWriterConfig,
+	inputChan chan writer.WriterInput[repository.InputSchema],
+	doneChan chan struct{},
+) (*PartitionWriter, error) {
+	if cfg.MaxFileSize <= 0 {
+		return nil, fmt.Errorf("MaxFileSize must be greater than 0")
+	}
+	if cfg.NumPartitions <= 0 {
+		return nil, fmt.Errorf("NumPartitions must be greater than 0")
+	}
+	if cfg.PartitionLevels <= 0 {
+		return nil, fmt.Errorf("PartitionLevels must be greater than 0")
+	}
+	if cfg.BaseDir == "" {
+		return nil, fmt.Errorf("BaseDir must not be empty")
+	}
+
+	w := &PartitionWriter{
+		BaseWriter: &xwaveWriter.BaseWriter[repository.InputSchema]{
+			InboxChannel: inputChan,
+			DoneChannel:  doneChan,
+		},
+		fs: &filesystemmanager.FileSystemManager{
+			Handler: partition.PartitionHandler{
+				NumPartitions:   cfg.NumPartitions,
+				PartitionLevels: cfg.PartitionLevels,
+			},
+			BaseDir: cfg.BaseDir,
+		},
+		maxFileSize: cfg.MaxFileSize,
+		dirMap:      make(map[string]int),
+		cfg:         cfg,
+	}
+	w.Writer = w
+	return w, nil
+}
+
+func (w *PartitionWriter) Receive(msg xwaveWriter.WriterInput[repository.InputSchema]) {
+	if msg.Error != nil {
+		panic(msg.Error)
+	}
+
+	err := w.write(msg.Rows, w.cfg.Schema)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (w *PartitionWriter) write(rows []repository.InputSchema, schema config.ParquetWriterSchema) error {
+	idMap := w.idMap(rows)
+
+	for id := range idMap {
+		dir, err := w.fs.GetDirectory(id)
+		if err != nil {
+			return fmt.Errorf("Error while getting directory for id %s\n%w", id, err)
+		}
+
+		dirChanged := w.currentDir != dir
+		if dirChanged {
+			w.currentDir = dir
+			_, err := w.fs.CreatePartition(id)
+			if err != nil {
+				return fmt.Errorf("Error while creating partition for id %s\n%w", id, err)
+			}
+		}
+
+		if w.currentFile == nil || w.fs.GetSizeOfFile(w.currentFile) > int64(w.maxFileSize) || dirChanged {
+			err := w.updateCurrentWriter(w.currentDir, schema)
+			if err != nil {
+				return fmt.Errorf("Error while updating current writer and file\n%w", err)
+			}
+		}
+
+		for _, rowIdx := range idMap[id] {
+			if err := w.currentWriter.Write(rows[rowIdx]); err != nil {
+				return fmt.Errorf("ParquetWriter could not write object %v\n%w", rows[rowIdx], err)
+			}
+			if w.fs.GetSizeOfFile(w.currentFile) > int64(w.maxFileSize) {
+				err := w.updateCurrentWriter(w.currentDir, schema)
+				if err != nil {
+					return fmt.Errorf("Error updating current writer and file due to file size\n%w", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (w *PartitionWriter) Stop() {
+	if err := w.closeResources(); err != nil {
+		panic(err)
+	}
+	w.DoneChannel <- struct{}{}
+	close(w.DoneChannel)
+}
+
+// Create a map of object ids and the indexes of their rows
+func (w *PartitionWriter) idMap(rows []repository.InputSchema) map[string][]int {
+	idMap := make(map[string][]int)
+
+	for i, row := range rows {
+		id := row.GetId()
+		if _, ok := idMap[id]; !ok {
+			idMap[id] = make([]int, 0)
+		}
+		idMap[id] = append(idMap[id], i)
+	}
+
+	return idMap
+}
+
+func (w *PartitionWriter) updateCurrentWriter(dir string, schema config.ParquetWriterSchema) error {
+	if err := w.closeResources(); err != nil {
+		return fmt.Errorf(
+			"Error closing resources while changing to a new file\n%w",
+			err,
+		)
+	}
+
+	updateCurrentDirFileIndex(w.dirMap, dir)
+
+	var err error
+	w.currentFile, err = w.fs.CreateNewFile(dir, w.dirMap[dir])
+	if err != nil {
+		return fmt.Errorf("Error while creating file\n%w", err)
+	}
+
+	w.currentWriter, err = w.createParquetWriter(w.currentFile, schema)
+	if err != nil {
+		return fmt.Errorf("ParquetGo could not create writer from writer\n%w", err)
+	}
+
+	return nil
+}
+
+func (w *PartitionWriter) createParquetWriter(file *os.File, schema config.ParquetWriterSchema) (*parquetWriter.ParquetWriter, error) {
+	var writerSchema any
+	switch schema {
+	case config.AllwiseSchema:
+		writerSchema = new(repository.AllwiseInputSchema)
+	case config.TestSchema:
+		writerSchema = new(TestInputSchema)
+	default:
+		panic("Unknown schema")
+	}
+	writer, err := parquetWriter.NewParquetWriterFromWriter(file, writerSchema, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return writer, nil
+}
+
+func (w *PartitionWriter) closeResources() error {
+	if w.currentWriter == nil || w.currentFile == nil {
+		return nil
+	}
+
+	if err := w.currentWriter.WriteStop(); err != nil {
+		return fmt.Errorf("ParquetWriter could not stop. %w", err)
+	}
+
+	if err := w.currentFile.Close(); err != nil {
+		return fmt.Errorf("ParquetWriter could not close parquet file %w", err)
+	}
+
+	return nil
+}
+
+func updateCurrentDirFileIndex(dirMap map[string]int, dir string) {
+	if _, ok := dirMap[dir]; !ok {
+		dirMap[dir] = 1
+	} else {
+		dirMap[dir]++
+	}
 }

--- a/service/internal/preprocessor/writer/partition_writer_integration_test.go
+++ b/service/internal/preprocessor/writer/partition_writer_integration_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partition_writer_test
+
+import (
+	"log/slog"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/writer"
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	"github.com/dirodriguezm/xmatch/service/internal/di"
+	partition_writer "github.com/dirodriguezm/xmatch/service/internal/preprocessor/writer"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+	"github.com/golobby/container/v3"
+	"github.com/stretchr/testify/suite"
+	"github.com/xitongsys/parquet-go-source/local"
+	"github.com/xitongsys/parquet-go/reader"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+	w          *partition_writer.PartitionWriter
+	configPath string
+	tmpDir     string
+	ctr        container.Container
+}
+
+func (s *IntegrationTestSuite) SetupSuite() {
+	os.Setenv("LOG_LEVEL", "debug")
+
+	// create a config file
+	tmpDir, err := os.MkdirTemp("", "partition_writer_integration_test_*")
+	if err != nil {
+		slog.Error("could not make temp dir")
+		panic(err)
+	}
+	s.tmpDir = tmpDir
+
+	s.configPath = partition_writer.CreateTestConfig()
+
+	s.ctr = di.BuildPreprocessorContainer()
+}
+
+func (s *IntegrationTestSuite) TearDownSuite() {
+	os.Remove(s.configPath)
+	os.Remove(s.tmpDir)
+}
+
+func (s *IntegrationTestSuite) SetupTest() {
+	err := s.ctr.Resolve(&s.w)
+	s.Require().NoError(err)
+}
+
+func (s *IntegrationTestSuite) TestActor() {
+	s.w.Start()
+
+	messages := []writer.WriterInput[repository.InputSchema]{
+		{
+			Rows: []repository.InputSchema{
+				partition_writer.NewTestRow("1", 1, "1"),
+				partition_writer.NewTestRow("2", 2, "2"),
+				partition_writer.NewTestRow("3", 3, "3"),
+			},
+		},
+	}
+
+	for _, msg := range messages {
+		s.w.InboxChannel <- msg
+	}
+	close(s.w.InboxChannel)
+	s.w.Done()
+
+	// check the parquet file
+	var cfg *config.Config
+	err := s.ctr.Resolve(&cfg)
+	s.Require().NoError(err)
+
+	// read the partition file
+	dir := cfg.Preprocessor.PartitionWriter.BaseDir
+	s.T().Log(os.ReadDir(dir))
+	result := s.read_helper(path.Join(dir, "0", "001.parquet"))
+	s.Require().Len(result, 3)
+	s.Require().Equal("1", *result[0].Id)
+	s.Require().Equal("2", *result[1].Id)
+	s.Require().Equal("3", *result[2].Id)
+}
+
+func (s *IntegrationTestSuite) read_helper(file string) []partition_writer.TestInputSchema {
+	s.T().Helper()
+
+	fr, err := local.NewLocalFileReader(file)
+	s.Require().NoError(err, "could not create local file reader")
+
+	pr, err := reader.NewParquetReader(fr, new(partition_writer.TestInputSchema), 4)
+	s.Require().NoError(err, "could not create parquet reader")
+
+	num := int(pr.GetNumRows())
+
+	rows := make([]partition_writer.TestInputSchema, num)
+	err = pr.Read(&rows)
+	s.Require().NoError(err, "could not read rows")
+
+	pr.ReadStop()
+	err = fr.Close()
+	s.Require().NoError(err, "could not close file reader")
+
+	return rows
+}
+
+func TestIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}

--- a/service/internal/preprocessor/writer/partition_writer_test.go
+++ b/service/internal/preprocessor/writer/partition_writer_test.go
@@ -1,0 +1,193 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partition_writer
+
+import (
+	"log/slog"
+	"os"
+	"path"
+	"testing"
+
+	xwaveWriter "github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/writer"
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	filesystemmanager "github.com/dirodriguezm/xmatch/service/internal/preprocessor/filesystem_manager"
+	"github.com/dirodriguezm/xmatch/service/internal/preprocessor/partition"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func NewTestRow(id string, column1 int, column2 string) TestInputSchema {
+	return TestInputSchema{
+		Id:      &id,
+		Column1: &column1,
+		Column2: &column2,
+	}
+}
+
+type IdMapSuite struct {
+	suite.Suite
+	writer *PartitionWriter
+}
+
+func (s *IdMapSuite) SetupTest() {
+	s.writer = &PartitionWriter{
+		BaseWriter: &xwaveWriter.BaseWriter[repository.InputSchema]{},
+		fs:         &filesystemmanager.FileSystemManager{},
+	}
+}
+
+func (s *IdMapSuite) TestEmptyList() {
+	rows := make([]repository.InputSchema, 0)
+
+	result := s.writer.idMap(rows)
+	require.Empty(s.T(), result)
+}
+
+func (s *IdMapSuite) TestWithRows() {
+	rows := []repository.InputSchema{
+		NewTestRow("id1", 1, "value1"),
+		NewTestRow("id1", 1, "value1"),
+		NewTestRow("id2", 2, "value2"),
+	}
+
+	result := s.writer.idMap(rows)
+	require.Len(s.T(), result, 2)
+	require.Equal(s.T(), []int{0, 1}, result["id1"])
+	require.Equal(s.T(), []int{2}, result["id2"])
+}
+
+func TestIdMapSuite(t *testing.T) {
+	suite.Run(t, new(IdMapSuite))
+}
+
+type updateCurrentWriterSuite struct {
+	suite.Suite
+	writer  *PartitionWriter
+	tempDir string
+}
+
+func (s *updateCurrentWriterSuite) SetupTest() {
+	s.writer = &PartitionWriter{
+		BaseWriter: &xwaveWriter.BaseWriter[repository.InputSchema]{},
+		fs:         &filesystemmanager.FileSystemManager{},
+		dirMap:     make(map[string]int),
+	}
+	s.tempDir = s.T().TempDir()
+}
+
+func (s *updateCurrentWriterSuite) TestWithFirstFile() {
+	err := s.writer.updateCurrentWriter(s.tempDir, config.TestSchema)
+	require.NoError(s.T(), err)
+	require.FileExists(s.T(), path.Join(s.tempDir, "001.parquet"))
+	require.NotNil(s.T(), s.writer.currentWriter)
+}
+
+func (s *updateCurrentWriterSuite) TestWithSecondFile() {
+	tmpFile, _ := os.CreateTemp(s.tempDir, "test")
+	s.writer.currentFile = tmpFile
+	s.writer.currentWriter, _ = s.writer.createParquetWriter(s.writer.currentFile, config.TestSchema)
+	s.writer.dirMap[s.tempDir] = 1
+
+	err := s.writer.updateCurrentWriter(s.tempDir, config.TestSchema)
+	require.NoError(s.T(), err)
+	require.Error(s.T(), tmpFile.Close())
+	require.FileExists(s.T(), path.Join(s.tempDir, "002.parquet"))
+	require.NotNil(s.T(), s.writer.currentWriter)
+}
+
+func TestUpdateCurrentWriterSuite(t *testing.T) {
+	suite.Run(t, new(updateCurrentWriterSuite))
+}
+
+type writeSuite struct {
+	suite.Suite
+	writer  *PartitionWriter
+	tempDir string
+}
+
+func (s *writeSuite) SetupTest() {
+	s.tempDir = s.T().TempDir()
+	s.writer = &PartitionWriter{
+		BaseWriter: &xwaveWriter.BaseWriter[repository.InputSchema]{},
+		fs: &filesystemmanager.FileSystemManager{
+			BaseDir: s.tempDir,
+			Handler: partition.PartitionHandler{
+				NumPartitions:   16,
+				PartitionLevels: 2,
+			},
+		},
+		maxFileSize: 300 * 1024 * 1024,
+		dirMap:      make(map[string]int),
+	}
+	setupTestLogger(s.T())
+}
+
+func (s *writeSuite) TestWrite() {
+	rows := []repository.InputSchema{
+		NewTestRow("id1", 1, "value1"),
+		NewTestRow("id1", 1, "value1"),
+		NewTestRow("id2", 2, "value2"),
+	}
+
+	err := s.writer.write(rows, config.TestSchema)
+	require.NoError(s.T(), err)
+
+	// now read the written files, but first we need to find them
+	assignedDir, err := s.writer.fs.GetDirectory("id1")
+	require.NoError(s.T(), err)
+	require.FileExists(s.T(), path.Join(assignedDir, "001.parquet"))
+
+	assignedDir, err = s.writer.fs.GetDirectory("id2")
+	require.NoError(s.T(), err)
+	require.FileExists(s.T(), path.Join(assignedDir, "001.parquet"))
+}
+
+func (s *writeSuite) TestWrite_when_file_is_full() {
+	rows := []repository.InputSchema{
+		NewTestRow("id1", 1, "value1"),
+		NewTestRow("id1", 1, "value1"),
+		NewTestRow("id2", 2, "value2"),
+	}
+
+	s.writer.maxFileSize = 1
+	err := s.writer.write(rows, config.TestSchema)
+	require.NoError(s.T(), err)
+
+	// now read the written files, but first we need to find them
+	assignedDir, err := s.writer.fs.GetDirectory("id1")
+	require.NoError(s.T(), err)
+	require.FileExists(s.T(), path.Join(assignedDir, "001.parquet"), "id1")
+	require.FileExists(s.T(), path.Join(assignedDir, "002.parquet"), "id1, second row")
+
+	assignedDir, err = s.writer.fs.GetDirectory("id2")
+	require.NoError(s.T(), err)
+	require.FileExists(s.T(), path.Join(assignedDir, "001.parquet"), "id2")
+}
+
+func TestWriteSuite(t *testing.T) {
+	suite.Run(t, new(writeSuite))
+}
+
+func setupTestLogger(t *testing.T) {
+	t.Helper()
+
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+}

--- a/service/internal/preprocessor/writer/test_helper.go
+++ b/service/internal/preprocessor/writer/test_helper.go
@@ -1,0 +1,84 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partition_writer
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+)
+
+type TestInputSchema struct {
+	Id      *string `parquet:"name=id, type=BYTE_ARRAY"`
+	Column1 *int    `parquet:"name=column1, type=INT64"`
+	Column2 *string `parquet:"name=column2, type=BYTE_ARRAY"`
+}
+
+func (r TestInputSchema) GetCoordinates() (float64, float64) {
+	return 0, 0
+}
+
+func (r TestInputSchema) ToMetadata() any {
+	return nil
+}
+
+func (r TestInputSchema) ToMastercat(ipix int64) repository.ParquetMastercat {
+	return repository.ParquetMastercat{}
+}
+
+func (r TestInputSchema) SetField(string, any) {}
+
+func (r TestInputSchema) GetId() string {
+	return *r.Id
+}
+
+func CreateTestConfig() string {
+	// create a config file
+	tmpDir, err := os.MkdirTemp("", "partition_writer_integration_test_*")
+	if err != nil {
+		slog.Error("could not make temp dir")
+		panic(err)
+	}
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	config := `
+reader:
+  batch_size: 500
+preprocessor:
+  source:
+    url: "buffer:"
+    type: "csv"
+    catalog_name: "test"
+  reader:
+    batch_size: 500
+    type: "csv"
+  partition_writer:
+    max_file_size: 104857600
+    num_partitions: 1
+    partition_levels: 1
+    base_dir: "%s"
+`
+	config = fmt.Sprintf(config, tmpDir)
+	err = os.WriteFile(configPath, []byte(config), 0644)
+	if err != nil {
+		slog.Error("could not write config file")
+		panic(err)
+	}
+	os.Setenv("CONFIG_PATH", configPath)
+	return configPath
+}

--- a/service/internal/repository/input_schema.go
+++ b/service/internal/repository/input_schema.go
@@ -21,6 +21,7 @@ type InputSchema interface {
 	ToMetadata() any
 	GetCoordinates() (float64, float64)
 	SetField(string, any)
+	GetId() string
 }
 
 type AllwiseInputSchema struct {
@@ -115,4 +116,8 @@ func (a *AllwiseInputSchema) SetField(name string, val any) {
 	case "k_msig_2mass":
 		a.K_msig_2mass = val.(*float64)
 	}
+}
+
+func (a *AllwiseInputSchema) GetId() string {
+	return *a.Source_id
 }


### PR DESCRIPTION
The `PartitionWriter` is a Go struct designed to handle the efficient writing of data into partitioned Parquet files. Its primary purpose is to manage the process of organizing, partitioning, and writing rows of data into Parquet files while adhering to configurable constraints such as file size, partitioning levels, and schema.

### Key Responsibilities:
1. **Partition Management**:
   - It uses a `FileSystemManager` to determine the appropriate directory for each data row based on its ID and the configured partitioning strategy (e.g., number of partitions and levels).
   - It ensures that data is written to the correct partition directory.

2. **File Management**:
   - It creates new Parquet files when necessary, such as when the current file exceeds the maximum file size or when switching to a new partition directory.
   - It maintains a mapping (`dirMap`) to track the file index for each directory.

3. **Data Writing**:
   - It writes rows of data into Parquet files using the `parquet-go` library.
   - It ensures that the same input schema is used for writing, as this preprocessing step does not alter data.

4. **Resource Management**:
   - It handles the lifecycle of Parquet writers and files, ensuring they are properly closed when no longer needed or when switching to a new file.

5. **Error Handling**:
   - It raises errors for invalid configurations (e.g., non-positive file size or partition levels) and for issues encountered during file or directory operations.

### Workflow:
- Data rows are received via the `Receive` method.
- The rows are grouped by their IDs into partitions using the `idMap` method.
- For each partition, the appropriate directory is determined, and a new file is created if necessary.
- Rows are written to the current Parquet file, and the file is rotated if it exceeds the maximum size.
- Resources are cleaned up when the writer is stopped.

In summary, the `PartitionWriter` is a utility for efficiently writing large datasets into partitioned Parquet files, ensuring scalability and organization of data for downstream processing or storage.

