### PR TITLE
Feature/partition reader

### DIFF
--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -70,10 +70,10 @@ type IndexerConfig struct {
 	Nside          int    `yaml:"nside"`
 }
 
-type ParquetWriterSchema int
+type ParquetSchema int
 
 const (
-	AllwiseSchema ParquetWriterSchema = iota
+	AllwiseSchema ParquetSchema = iota
 	MastercatSchema
 	TestSchema
 )
@@ -83,11 +83,11 @@ type WriterConfig struct {
 
 	// parquet config
 	OutputFile string `yaml:"output_file"`
-	Schema     ParquetWriterSchema
+	Schema     ParquetSchema
 }
 
 type PartitionWriterConfig struct {
-	Schema      ParquetWriterSchema
+	Schema      ParquetSchema
 	MaxFileSize int `yaml:"max_file_size"`
 
 	// filesystem config

--- a/service/internal/preprocessor/reader/partition_reader_test.go
+++ b/service/internal/preprocessor/reader/partition_reader_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partition_reader
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PartitionReaderTestSuite struct {
+	suite.Suite
+	baseDir string
+}
+
+func (suite *PartitionReaderTestSuite) SetupSuite() {
+	suite.baseDir = suite.T().TempDir()
+}
+
+func (suite *PartitionReaderTestSuite) TearDownSuite() {
+}
+
+func TestPartitionReaderTestSuite(t *testing.T) {
+	suite.Run(t, new(PartitionReaderTestSuite))
+}
+
+func (suite *PartitionReaderTestSuite) TestTraversePartitions() {
+	os.MkdirAll(path.Join(suite.baseDir, "a", "b", "c"), 0777)
+	os.WriteFile(path.Join(suite.baseDir, "a", "b", "c", "file1"), []byte("test"), 0777)
+	os.WriteFile(path.Join(suite.baseDir, "a", "b", "c", "file2"), []byte("test"), 0777)
+	os.MkdirAll(path.Join(suite.baseDir, "a", "b", "d"), 0777)
+	os.WriteFile(path.Join(suite.baseDir, "a", "b", "d", "file1"), []byte("test"), 0777)
+	os.MkdirAll(path.Join(suite.baseDir, "a", "b", "e"), 0777)
+
+	outputChan := make(chan string, 4)
+	pr := NewPartitionReader(outputChan)
+	go func() {
+		err := pr.TraversePartitions(suite.baseDir)
+		suite.Nil(err)
+		close(outputChan)
+	}()
+
+	directories := make([]string, 0)
+	for dir := range outputChan {
+		directories = append(directories, dir)
+	}
+
+	suite.Len(directories, 2)
+	suite.Equal(directories[0], path.Join(suite.baseDir, "a", "b", "c"))
+	suite.Equal(directories[1], path.Join(suite.baseDir, "a", "b", "d"))
+}

--- a/service/internal/preprocessor/reader/test_helper.go
+++ b/service/internal/preprocessor/reader/test_helper.go
@@ -1,0 +1,60 @@
+package partition_reader
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+	"github.com/xitongsys/parquet-go/writer"
+)
+
+type TestInputSchema struct {
+	Id      *string `parquet:"name=id, type=BYTE_ARRAY"`
+	Column1 *int    `parquet:"name=column1, type=INT64"`
+	Column2 *string `parquet:"name=column2, type=BYTE_ARRAY"`
+}
+
+func (r TestInputSchema) GetCoordinates() (float64, float64) {
+	return 0, 0
+}
+
+func (r TestInputSchema) ToMetadata() any {
+	return nil
+}
+
+func (r TestInputSchema) ToMastercat(ipix int64) repository.ParquetMastercat {
+	return repository.ParquetMastercat{}
+}
+
+func (r TestInputSchema) SetField(string, any) {}
+
+func (r TestInputSchema) GetId() string {
+	return *r.Id
+}
+
+func writeParquet(t *testing.T, file *os.File, rows []TestInputSchema) {
+	t.Helper()
+
+	pr, err := writer.NewParquetWriterFromWriter(file, new(TestInputSchema), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, row := range rows {
+		if err := pr.Write(row); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := pr.WriteStop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/service/internal/preprocessor/reader/worker.go
+++ b/service/internal/preprocessor/reader/worker.go
@@ -1,0 +1,146 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partition_reader
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+	"github.com/xitongsys/parquet-go-source/local"
+	"github.com/xitongsys/parquet-go/reader"
+)
+
+type Records = []repository.InputSchema
+
+type Worker struct {
+	dirChannel <-chan string
+	schema     config.ParquetSchema
+	output     chan<- Records
+}
+
+func NewWorker(dirChannel <-chan string, schema config.ParquetSchema, output chan<- Records) *Worker {
+	return &Worker{
+		dirChannel: dirChannel,
+		schema:     schema,
+		output:     output,
+	}
+}
+
+func (w *Worker) Start() {
+	for dir := range w.dirChannel {
+		records, err := w.readDirectory(dir)
+		if err != nil {
+			panic(err)
+		}
+
+		groupedRecords := w.groupByOid(records)
+		for _, records := range groupedRecords {
+			w.output <- records
+		}
+	}
+	close(w.output)
+}
+
+func (w *Worker) readDirectory(dir string) (Records, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make(Records, 0)
+	for _, file := range files {
+		if file.IsDir() {
+			panic(fmt.Errorf("found directory in partition: %s", file.Name()))
+		}
+
+		newRecords, err := w.readFile(filepath.Join(dir, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, newRecords...)
+	}
+
+	return records, nil
+}
+
+func (w *Worker) readFile(file string) (Records, error) {
+	fr, err := local.NewLocalFileReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file %s: %w", file, err)
+	}
+	defer fr.Close()
+
+	pr, err := reader.NewParquetReader(fr, getParquetSchema(w.schema), 1)
+	if err != nil {
+		return nil, fmt.Errorf("error creating parquet reader: %w", err)
+	}
+	defer pr.ReadStop()
+
+	num := int(pr.GetNumRows())
+	switch w.schema {
+	case config.AllwiseSchema:
+		records := make([]repository.AllwiseInputSchema, num)
+		if err = pr.Read(&records); err != nil {
+			return nil, fmt.Errorf("error reading parquet file: %w", err)
+		}
+		return convertAllwiseToInputSchema(records), nil
+	case config.TestSchema:
+		records := make([]TestInputSchema, num)
+		if err = pr.Read(&records); err != nil {
+			return nil, fmt.Errorf("error reading parquet file: %w", err)
+		}
+		return convertTestToInputSchema(records), nil
+	default:
+		panic("Unknown schema")
+	}
+}
+
+func (w *Worker) groupByOid(records Records) map[string]Records {
+	result := make(map[string]Records)
+	for i := 0; i < len(records); i++ {
+		result[records[i].GetId()] = append(result[records[i].GetId()], records[i])
+	}
+	return result
+}
+
+func getParquetSchema(schema config.ParquetSchema) any {
+	switch schema {
+	case config.AllwiseSchema:
+		return new(repository.AllwiseInputSchema)
+	case config.TestSchema:
+		return new(TestInputSchema)
+	default:
+		panic("Unknown schema")
+	}
+}
+
+func convertAllwiseToInputSchema(records []repository.AllwiseInputSchema) []repository.InputSchema {
+	result := make([]repository.InputSchema, len(records))
+	for i, r := range records {
+		result[i] = &r
+	}
+	return result
+}
+
+func convertTestToInputSchema(records []TestInputSchema) []repository.InputSchema {
+	result := make([]repository.InputSchema, len(records))
+	for i, r := range records {
+		result[i] = &r
+	}
+	return result
+}

--- a/service/internal/preprocessor/reader/worker_test.go
+++ b/service/internal/preprocessor/reader/worker_test.go
@@ -1,0 +1,145 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package partition_reader
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	"github.com/stretchr/testify/suite"
+)
+
+type WorkerSuite struct {
+	suite.Suite
+}
+
+func TestWorkerSuite(t *testing.T) {
+	suite.Run(t, new(WorkerSuite))
+}
+
+func (s *WorkerSuite) TestReadDirectory() {
+	dirChan := make(chan string, 1)
+	worker := NewWorker(dirChan, config.TestSchema, make(chan Records, 1))
+	dir := s.T().TempDir()
+
+	s.T().Run("empty directory", func(t *testing.T) {
+		records, err := worker.readDirectory(dir)
+		s.Nil(err)
+
+		s.Len(records, 0)
+	})
+
+	s.T().Run("with file", func(t *testing.T) {
+		file, err := os.Create(path.Join(dir, "test.parquet"))
+		s.Require().Nil(err)
+		defer func() {
+			if err := file.Close(); err != nil {
+				t.Error(err)
+			}
+			os.Remove(file.Name())
+		}()
+		writeParquet(s.T(), file, []TestInputSchema{{Id: stringPtr("test")}})
+		records, err := worker.readDirectory(dir)
+		s.Nil(err)
+
+		s.Len(records, 1)
+		s.Equal(records[0].GetId(), "test")
+	})
+}
+
+func (s *WorkerSuite) TestGroupByOid() {
+	testCases := []struct {
+		records  []TestInputSchema
+		expected map[string]Records
+	}{
+		{
+			records: []TestInputSchema{{Id: stringPtr("test")}, {Id: stringPtr("test")}},
+			expected: map[string]Records{
+				"test": {
+					&TestInputSchema{Id: stringPtr("test")},
+					&TestInputSchema{Id: stringPtr("test")},
+				},
+			},
+		},
+		{
+			records:  []TestInputSchema{},
+			expected: map[string]Records{},
+		},
+		{
+			records: []TestInputSchema{{Id: stringPtr("test")}, {Id: stringPtr("test")}, {Id: stringPtr("test2")}},
+			expected: map[string]Records{
+				"test": {
+					&TestInputSchema{Id: stringPtr("test")},
+					&TestInputSchema{Id: stringPtr("test")},
+				},
+				"test2": {
+					&TestInputSchema{Id: stringPtr("test2")},
+				},
+			},
+		},
+	}
+
+	worker := NewWorker(make(chan string, 1), config.TestSchema, make(chan Records, 1))
+	for _, tc := range testCases {
+		records := make(Records, len(tc.records))
+		for i := 0; i < len(tc.records); i++ {
+			records[i] = &tc.records[i]
+		}
+		groupedRecords := worker.groupByOid(records)
+
+		s.Equal(tc.expected, groupedRecords)
+	}
+}
+
+func (s *WorkerSuite) TestStart() {
+	dir := s.T().TempDir()
+
+	s.T().Run("empty directory", func(t *testing.T) {
+		dirChan := make(chan string, 1)
+		output := make(chan Records, 1)
+		worker := NewWorker(dirChan, config.TestSchema, output)
+		go worker.Start()
+		dirChan <- dir
+		close(dirChan)
+
+		records := <-output
+		s.Len(records, 0)
+	})
+
+	s.T().Run("with file", func(t *testing.T) {
+		file, err := os.Create(path.Join(dir, "test.parquet"))
+		s.Require().Nil(err)
+		defer func() {
+			if err := file.Close(); err != nil {
+				t.Error(err)
+			}
+			os.Remove(file.Name())
+		}()
+		writeParquet(s.T(), file, []TestInputSchema{{Id: stringPtr("test")}})
+
+		dirChan := make(chan string, 1)
+		output := make(chan Records, 1)
+		worker := NewWorker(dirChan, config.TestSchema, output)
+		go worker.Start()
+		dirChan <- dir
+		close(dirChan)
+
+		records := <-output
+		s.Len(records, 1)
+		s.Equal(records[0].GetId(), "test")
+	})
+}

--- a/service/internal/preprocessor/writer/parquet_store.go
+++ b/service/internal/preprocessor/writer/parquet_store.go
@@ -30,7 +30,7 @@ import (
 type ParquetStore struct {
 	fs      *filesystemmanager.FileSystemManager
 	maxSize int
-	schema  config.ParquetWriterSchema
+	schema  config.ParquetSchema
 }
 
 func (store *ParquetStore) Write(rowsToWrite map[string][]repository.InputSchema, dirMap map[string]int) (map[string]int, error) {
@@ -198,7 +198,7 @@ func (store *ParquetStore) readTestSchema(pr *reader.ParquetReader, nrows int64)
 	return result, nil
 }
 
-func getParquetSchema(schema config.ParquetWriterSchema) any {
+func getParquetSchema(schema config.ParquetSchema) any {
 	switch schema {
 	case config.AllwiseSchema:
 		return new(repository.AllwiseInputSchema)


### PR DESCRIPTION
I'll analyze this pull request and provide a comprehensive summary.

# Pull Request Summary: Refactor Parquet Schema and Add Partition Reader Implementation

## Overview
This PR introduces significant changes to the catalog indexing system, primarily in the preprocessor package. It renames `ParquetWriterSchema` to `ParquetSchema` for consistency and implements a complete partition reader system with worker concurrency support.

## Key Changes

### 1. Schema Type Renaming
- Renamed `ParquetWriterSchema` to `ParquetSchema` across the codebase for better semantic clarity, as the schema is used by both readers and writers.

### 2. New Partition Reader Implementation
- Completely reimplemented the `PartitionReader` package with:
  - A directory traversal system that finds all leaf directories containing data files
  - A channel-based architecture for concurrent processing
  - Support for different parquet schemas (AllwiseSchema, TestSchema)

### 3. Worker Implementation
- Added a concurrent worker system that:
  - Consumes directory paths from a channel
  - Reads all parquet files within each directory
  - Groups records by object ID
  - Outputs record groups to downstream consumers

### 4. Testing Infrastructure
- Added comprehensive test suites:
  - `PartitionReaderTestSuite` verifies directory traversal
  - `WorkerSuite` tests data reading and record grouping
  - Test helper utilities for creating test data

## Design
![image](https://github.com/user-attachments/assets/55dd5328-5c1a-45c3-836f-f01656953b28)
