### PR TITLE
feat: partition reader starts workers configured in container

### DIFF
--- a/service/cmd/main.go
+++ b/service/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dirodriguezm/xmatch/service/internal/config"
 	"github.com/dirodriguezm/xmatch/service/internal/di"
 	httpservice "github.com/dirodriguezm/xmatch/service/internal/http_service"
+	partition_reader "github.com/dirodriguezm/xmatch/service/internal/preprocessor/reader"
 	partition_writer "github.com/dirodriguezm/xmatch/service/internal/preprocessor/writer"
 	"github.com/dirodriguezm/xmatch/service/internal/repository"
 )
@@ -99,10 +100,13 @@ func startPreprocessor() {
 	ctr.Resolve(&partition_w)
 	partition_w.Start()
 
-	// initialize reader
+	// initialize source reader
 	var reader reader.Reader
 	ctr.Resolve(&reader)
 	reader.Start()
+
+	var cfg *config.Config
+	ctr.Resolve(&cfg)
 
 	readerResults := reader.GetOutbox()
 	go func() {
@@ -118,8 +122,12 @@ func startPreprocessor() {
 			}
 		}
 	}()
-
 	partition_w.Done()
+
+	// Now the partition reader part
+	var partition_r *partition_reader.PartitionReader
+	ctr.Resolve(&partition_r)
+	partition_r.Start()
 }
 
 func main() {

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -43,6 +43,7 @@ type PreprocessorConfig struct {
 	Source          *SourceConfig          `yaml:"source"`
 	Reader          *ReaderConfig          `yaml:"reader"`
 	PartitionWriter *PartitionWriterConfig `yaml:"partition_writer"`
+	PartitionReader *PartitionReaderConfig `yaml:"partition_reader"`
 }
 
 type SourceConfig struct {
@@ -97,6 +98,10 @@ type PartitionWriterConfig struct {
 
 	// In Memory Store config
 	InMemoryMaxPartitionSize int `yaml:"in_memory_max_partition_size"`
+}
+
+type PartitionReaderConfig struct {
+	NumWorkers int `yaml:"num_workers"`
 }
 
 type ServiceConfig struct {

--- a/service/internal/preprocessor/reader/partition_reader.go
+++ b/service/internal/preprocessor/reader/partition_reader.go
@@ -17,35 +17,55 @@ package partition_reader
 import (
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 type PartitionReader struct {
 	dirChannel chan<- string
+	workers    []*Worker
+	baseDir    string
 }
 
-func NewPartitionReader(dirChannel chan<- string) *PartitionReader {
+func NewPartitionReader(dirChannel chan<- string, workers []*Worker, baseDir string) *PartitionReader {
 	return &PartitionReader{
 		dirChannel: dirChannel,
+		workers:    workers,
+		baseDir:    baseDir,
 	}
 }
 
 // Recursively traverse the directory tree
 // sending each leaf directory to the output channel
-func (pr *PartitionReader) TraversePartitions(baseDir string) error {
+func (pr *PartitionReader) TraversePartitions(baseDir string) {
 	entries, err := os.ReadDir(baseDir)
 	if err != nil {
-		return err
+		panic(err)
 	}
+
 	for _, entry := range entries {
 		if entry.IsDir() {
-			err := pr.TraversePartitions(filepath.Join(baseDir, entry.Name()))
-			if err != nil {
-				return err
-			}
+			pr.TraversePartitions(filepath.Join(baseDir, entry.Name()))
 		} else {
 			pr.dirChannel <- baseDir
-			return nil
+			return
 		}
 	}
-	return nil
+}
+
+// Start the partition reader
+// This will traverse the directory tree and send each leaf directory to the output channel
+// The workers will read from the directory channel and send the records to the output channel
+// The directory channel and worker output channel will be closed when the workers are done
+func (pr *PartitionReader) Start() {
+	go pr.TraversePartitions(pr.baseDir)
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(pr.workers))
+	for _, worker := range pr.workers {
+		go worker.Start(&wg)
+	}
+	wg.Wait()
+
+	close(pr.dirChannel)
+	close(pr.workers[0].output)
 }

--- a/service/internal/preprocessor/reader/partition_reader_test.go
+++ b/service/internal/preprocessor/reader/partition_reader_test.go
@@ -46,16 +46,15 @@ func (suite *PartitionReaderTestSuite) TestTraversePartitions() {
 	os.WriteFile(path.Join(suite.baseDir, "a", "b", "d", "file1"), []byte("test"), 0777)
 	os.MkdirAll(path.Join(suite.baseDir, "a", "b", "e"), 0777)
 
-	outputChan := make(chan string, 4)
-	pr := NewPartitionReader(outputChan)
+	dirChan := make(chan string, 4)
+	pr := NewPartitionReader(dirChan, nil, suite.baseDir)
 	go func() {
-		err := pr.TraversePartitions(suite.baseDir)
-		suite.Nil(err)
-		close(outputChan)
+		pr.TraversePartitions(suite.baseDir)
+		close(dirChan)
 	}()
 
 	directories := make([]string, 0)
-	for dir := range outputChan {
+	for dir := range dirChan {
 		directories = append(directories, dir)
 	}
 

--- a/service/internal/preprocessor/reader/worker.go
+++ b/service/internal/preprocessor/reader/worker.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/dirodriguezm/xmatch/service/internal/config"
 	"github.com/dirodriguezm/xmatch/service/internal/repository"
@@ -41,7 +42,9 @@ func NewWorker(dirChannel <-chan string, schema config.ParquetSchema, output cha
 	}
 }
 
-func (w *Worker) Start() {
+func (w *Worker) Start(wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	for dir := range w.dirChannel {
 		records, err := w.readDirectory(dir)
 		if err != nil {
@@ -53,7 +56,6 @@ func (w *Worker) Start() {
 			w.output <- records
 		}
 	}
-	close(w.output)
 }
 
 func (w *Worker) readDirectory(dir string) (Records, error) {

--- a/service/internal/preprocessor/reader/worker_test.go
+++ b/service/internal/preprocessor/reader/worker_test.go
@@ -17,6 +17,7 @@ package partition_reader
 import (
 	"os"
 	"path"
+	"sync"
 	"testing"
 
 	"github.com/dirodriguezm/xmatch/service/internal/config"
@@ -112,9 +113,13 @@ func (s *WorkerSuite) TestStart() {
 		dirChan := make(chan string, 1)
 		output := make(chan Records, 1)
 		worker := NewWorker(dirChan, config.TestSchema, output)
-		go worker.Start()
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go worker.Start(&wg)
 		dirChan <- dir
 		close(dirChan)
+		wg.Wait()
+		close(output)
 
 		records := <-output
 		s.Len(records, 0)
@@ -134,9 +139,13 @@ func (s *WorkerSuite) TestStart() {
 		dirChan := make(chan string, 1)
 		output := make(chan Records, 1)
 		worker := NewWorker(dirChan, config.TestSchema, output)
-		go worker.Start()
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go worker.Start(&wg)
 		dirChan <- dir
 		close(dirChan)
+		wg.Wait()
+		close(output)
 
 		records := <-output
 		s.Len(records, 1)

--- a/service/internal/preprocessor/writer/test_helper.go
+++ b/service/internal/preprocessor/writer/test_helper.go
@@ -101,6 +101,8 @@ preprocessor:
     num_partitions: 1
     partition_levels: 1
     base_dir: "%s"
+  partition_reader:
+    num_workers: 1
 `
 	config = fmt.Sprintf(config, tmpDir)
 	err = os.WriteFile(configPath, []byte(config), 0644)

--- a/service/justfile
+++ b/service/justfile
@@ -8,7 +8,7 @@ build:
 	go build -o build/main cmd/main.go
 
 test:
-	go test ./...
+	go test ./... -race
 
 export CONFIG_PATH := env_var_or_default("CONFIG_PATH", "config.yaml")
 


### PR DESCRIPTION


**Overview**  
Added a new PartitionReader component to the preprocessor service that reads partitioned data files in parallel using worker goroutines.

**Key Changes**:
1. **New PartitionReader Component**:
   - Added `PartitionReader` with worker pool pattern to process directories in parallel
   - Workers read parquet files from directories and emit records
   - Includes graceful shutdown with WaitGroup synchronization

2. **Configuration**:
   - Added `PartitionReaderConfig` with `NumWorkers` parameter
   - Updated DI container to initialize reader and workers

3. **Integration**:
   - Added PartitionReader to main preprocessor flow after writer completes
   - Updated test helpers and configs to support new component

4. **Testing**:
   - Added/updated unit tests for PartitionReader and Worker
   - Enabled race detector in test command

5. **Code Quality**:
   - Improved error handling (panics on critical errors)
   - Better resource cleanup (channel closing)
   - More robust directory traversal

