### PR TITLE
chore(#49): Make run function to inject testing os.getenv, os.stderr, os.stdout, os.stdin for better testing

### DIFF
--- a/service/cmd/main.go
+++ b/service/cmd/main.go
@@ -15,8 +15,10 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"runtime/pprof"
@@ -44,8 +46,12 @@ import (
 // @BasePath		/v1
 // @contact.name	Diego Rodriguez Mancini
 // @contact.email	diegorodriguezmancini@gmail.com
-func startHttpServer() {
-	ctr := di.BuildServiceContainer()
+func startHttpServer(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+) error {
+	ctr := di.BuildServiceContainer(ctx, getenv, stdout)
 	var api *api.API
 	var web *web.Web
 	ctr.Resolve(&api)
@@ -55,42 +61,66 @@ func startHttpServer() {
 	api.SetupRoutes(r)
 	web.SetupRoutes(r)
 
-	r.Run()
+	err := r.Run()
+	return err
 }
 
-func startCatalogIndexer() {
+func startCatalogIndexer(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+) error {
 	slog.Debug("Starting catalog indexer")
-	ctr := di.BuildIndexerContainer()
+	ctr := di.BuildIndexerContainer(ctx, getenv, stdout)
 
 	var cfg *config.Config
-	ctr.Resolve(&cfg)
+	err := ctr.Resolve(&cfg)
+	if err != nil {
+		return err
+	}
 
 	// update catalogs table
 	var catalogRegister *indexer.CatalogRegister
-	ctr.Resolve(&catalogRegister)
+	err = ctr.Resolve(&catalogRegister)
+	if err != nil {
+		return err
+	}
 	catalogRegister.RegisterCatalog()
 
 	// initialize w
 	var w writer.Writer[any]
-	ctr.NamedResolve(&w, "indexer_writer")
+	err = ctr.NamedResolve(&w, "indexer_writer")
+	if err != nil {
+		return err
+	}
+
 	w.Start()
 
 	// initialize metadata writer
 	if cfg.CatalogIndexer.MetadataWriter != nil && cfg.CatalogIndexer.Source.Metadata {
 		var metadataWriter writer.Writer[any]
-		ctr.NamedResolve(&metadataWriter, "metadata_writer")
+		err := ctr.NamedResolve(&metadataWriter, "metadata_writer")
+		if err != nil {
+			return err
+		}
 		metadataWriter.Start()
 	}
 
 	// initialize indexer
 	var catalogIndexer *mastercat_indexer.IndexerActor
-	ctr.Resolve(&catalogIndexer)
+	err = ctr.Resolve(&catalogIndexer)
+	if err != nil {
+		return err
+	}
 	catalogIndexer.Start()
 
 	// initialize metadata indexer
 	if cfg.CatalogIndexer.Source.Metadata && cfg.CatalogIndexer.MetadataWriter != nil {
 		var actor *metadata_indexer.IndexerActor
-		ctr.Resolve(&actor)
+		err := ctr.Resolve(&actor)
+		if err != nil {
+			return err
+		}
 		actor.Start()
 	}
 
@@ -100,23 +130,37 @@ func startCatalogIndexer() {
 	reader.Start()
 
 	w.Done()
+	return nil
 }
 
-func startPreprocessor() {
-	ctr := di.BuildPreprocessorContainer()
+func startPreprocessor(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+) error {
+	ctr := di.BuildPreprocessorContainer(ctx, getenv, stdout)
 
 	// initialize partition_writer
 	var partition_w *partition_writer.PartitionWriter
-	ctr.Resolve(&partition_w)
+	err := ctr.Resolve(&partition_w)
+	if err != nil {
+		return err
+	}
 	partition_w.Start()
 
 	// initialize source reader
 	var reader reader.Reader
-	ctr.Resolve(&reader)
+	err = ctr.Resolve(&reader)
+	if err != nil {
+		return err
+	}
 	reader.Start()
 
 	var cfg *config.Config
-	ctr.Resolve(&cfg)
+	err = ctr.Resolve(&cfg)
+	if err != nil {
+		return err
+	}
 
 	readerResults := reader.GetOutbox()
 	go func() {
@@ -136,24 +180,55 @@ func startPreprocessor() {
 
 	// Now the partition reader part
 	var reducer *reducer.Reducer
-	ctr.Resolve(&reducer)
+	err = ctr.Resolve(&reducer)
+	if err != nil {
+		return err
+	}
 	reducer.Start()
 
 	var partition_r *partition_reader.PartitionReader
-	ctr.Resolve(&partition_r)
+	err = ctr.Resolve(&partition_r)
+	if err != nil {
+		return err
+	}
 	partition_r.Start()
 
 	partition_r.Done()
 	reducer.Done()
+	return nil
 }
 
 func main() {
-	slog.Info("Starting xmatch service")
-	profile := flag.CommandLine.Bool("profile", false, "Enable profiling")
-	flag.Parse()
-	command := flag.Arg(0)
+	ctx := context.Background()
+	if err := run(ctx, os.Getenv, os.Stdout, os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}
 
-	if *profile {
+func run(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+	args []string,
+) error {
+	slog.Info("Starting xmatch service")
+
+	if len(args) < 2 {
+		panic("run: Missing arguments")
+	}
+	fs := flag.NewFlagSet("xmatch", flag.ContinueOnError)
+
+	var profile bool
+	fs.BoolVar(&profile, "profile", false, "Enable profiling")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	command := args[1]
+
+	if profile {
 		slog.Info("Profiling enabled")
 		cpuFile, _ := os.Create("cpu.prof")
 		defer cpuFile.Close()
@@ -163,12 +238,13 @@ func main() {
 
 	switch command {
 	case "server":
-		startHttpServer()
+		return startHttpServer(ctx, getenv, stdout)
 	case "indexer":
-		startCatalogIndexer()
+		return startCatalogIndexer(ctx, getenv, stdout)
 	case "preprocessor":
-		startPreprocessor()
+		return startPreprocessor(ctx, getenv, stdout)
 	default:
 		fmt.Printf("Unknown command: %s\n", command)
 	}
+	return nil
 }

--- a/service/internal/api/api.go
+++ b/service/internal/api/api.go
@@ -26,12 +26,14 @@ type API struct {
 	conesearchService *conesearch.ConesearchService
 	metadataService   *metadata.MetadataService
 	config            *config.ServiceConfig
+	getenv            func(string) string
 }
 
 func New(
 	conesearchService *conesearch.ConesearchService,
 	metadataService *metadata.MetadataService,
 	config *config.ServiceConfig,
+	getenv func(string) string,
 ) (*API, error) {
 	if conesearchService == nil {
 		return nil, fmt.Errorf("ConesearchService was nil while creating HttpServer")
@@ -39,5 +41,5 @@ func New(
 	if metadataService == nil {
 		return nil, fmt.Errorf("MetadataService was nil while creating HttpServer")
 	}
-	return &API{conesearchService, metadataService, config}, nil
+	return &API{conesearchService, metadataService, config, getenv}, nil
 }

--- a/service/internal/api/routes.go
+++ b/service/internal/api/routes.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -28,7 +27,7 @@ func (api *API) SetupRoutes(r *gin.Engine) {
 		panic("api: gin engine cannot be nil")
 	}
 	r.Use(gin.Recovery())
-	if os.Getenv("USE_LOGGER") != "" {
+	if api.getenv("USE_LOGGER") != "" {
 		r.Use(gin.Logger())
 	}
 

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -121,8 +121,8 @@ type DatabaseConfig struct {
 	Url string `yaml:"url"`
 }
 
-func Load() (*Config, error) {
-	configPath := os.Getenv("CONFIG_PATH")
+func Load(getEnv func(string) string) (*Config, error) {
+	configPath := getEnv("CONFIG_PATH")
 	slog.Info("Loading configuration", "path", configPath)
 	if configPath == "" {
 		rootPath, err := utils.FindRootModulePath(5)

--- a/service/internal/di/indexer_container.go
+++ b/service/internal/di/indexer_container.go
@@ -17,6 +17,7 @@ package di
 import (
 	"context"
 	"database/sql"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -36,11 +37,15 @@ import (
 	"github.com/golobby/container/v3"
 )
 
-func BuildIndexerContainer() container.Container {
+func BuildIndexerContainer(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+) container.Container {
 	ctr := container.New()
 	// read config
 	ctr.Singleton(func() *config.Config {
-		cfg, err := config.Load()
+		cfg, err := config.Load(getenv)
 		if err != nil {
 			panic(err)
 		}
@@ -56,7 +61,7 @@ func BuildIndexerContainer() container.Container {
 			"":      slog.LevelInfo,
 		}
 		var programLevel = new(slog.LevelVar)
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: programLevel}))
+		logger := slog.New(slog.NewJSONHandler(stdout, &slog.HandlerOptions{Level: programLevel}))
 		slog.SetDefault(logger)
 		programLevel.Set(levels[os.Getenv("LOG_LEVEL")])
 		return programLevel

--- a/service/internal/di/preprocessor_container.go
+++ b/service/internal/di/preprocessor_container.go
@@ -15,9 +15,10 @@
 package di
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/reader"
@@ -33,11 +34,15 @@ import (
 	"github.com/golobby/container/v3"
 )
 
-func BuildPreprocessorContainer() container.Container {
+func BuildPreprocessorContainer(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+) container.Container {
 	ctr := container.New()
 
 	ctr.Singleton(func() *config.Config {
-		cfg, err := config.Load()
+		cfg, err := config.Load(getenv)
 		if err != nil {
 			panic(err)
 		}
@@ -53,9 +58,9 @@ func BuildPreprocessorContainer() container.Container {
 			"":      slog.LevelInfo,
 		}
 		var programLevel = new(slog.LevelVar)
-		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: programLevel}))
+		logger := slog.New(slog.NewJSONHandler(stdout, &slog.HandlerOptions{Level: programLevel}))
 		slog.SetDefault(logger)
-		programLevel.Set(levels[os.Getenv("LOG_LEVEL")])
+		programLevel.Set(levels[getenv("LOG_LEVEL")])
 		return programLevel
 	})
 

--- a/service/internal/preprocessor/writer/in_memory_store_test.go
+++ b/service/internal/preprocessor/writer/in_memory_store_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log/slog"
 	"path"
+	"strings"
 	"testing"
 
 	filesystemmanager "github.com/dirodriguezm/xmatch/service/internal/preprocessor/filesystem_manager"
@@ -15,6 +16,7 @@ type InMemoryStoreSuite struct {
 	suite.Suite
 	store  *InMemoryStore
 	tmpDir string
+	stdout io.Writer
 }
 
 func setupTestLogger(t *testing.T, stdout io.Writer) {
@@ -28,8 +30,10 @@ func setupTestLogger(t *testing.T, stdout io.Writer) {
 	slog.SetDefault(logger)
 }
 
-func (suite *InMemoryStoreSuite) SetupSuite(stdout io.Writer) {
+func (suite *InMemoryStoreSuite) SetupSuite() {
+	stdout := &strings.Builder{}
 	setupTestLogger(suite.T(), stdout)
+	suite.stdout = stdout
 }
 
 func (suite *InMemoryStoreSuite) SetupTest() {

--- a/service/internal/preprocessor/writer/in_memory_store_test.go
+++ b/service/internal/preprocessor/writer/in_memory_store_test.go
@@ -1,8 +1,8 @@
 package partition_writer
 
 import (
+	"io"
 	"log/slog"
-	"os"
 	"path"
 	"testing"
 
@@ -17,10 +17,10 @@ type InMemoryStoreSuite struct {
 	tmpDir string
 }
 
-func setupTestLogger(t *testing.T) {
+func setupTestLogger(t *testing.T, stdout io.Writer) {
 	t.Helper()
 
-	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	handler := slog.NewTextHandler(stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})
 
@@ -28,8 +28,8 @@ func setupTestLogger(t *testing.T) {
 	slog.SetDefault(logger)
 }
 
-func (suite *InMemoryStoreSuite) SetupSuite() {
-	setupTestLogger(suite.T())
+func (suite *InMemoryStoreSuite) SetupSuite(stdout io.Writer) {
+	setupTestLogger(suite.T(), stdout)
 }
 
 func (suite *InMemoryStoreSuite) SetupTest() {

--- a/service/internal/preprocessor/writer/partition_writer_actor_test.go
+++ b/service/internal/preprocessor/writer/partition_writer_actor_test.go
@@ -15,10 +15,12 @@
 package partition_writer_test
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/writer"
@@ -41,8 +43,6 @@ type IntegrationTestSuite struct {
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
-	os.Setenv("LOG_LEVEL", "debug")
-
 	// create a config file
 	tmpDir, err := os.MkdirTemp("", "partition_writer_integration_test_*")
 	if err != nil {
@@ -53,7 +53,20 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	s.configPath = partition_writer.CreateTestConfig(filepath.Join(tmpDir, "output.parquet"))
 
-	s.ctr = di.BuildPreprocessorContainer()
+	getenv := func(key string) string {
+		switch key {
+		case "LOG_LEVEL":
+			return "debug"
+		case "CONFIG_PATH":
+			return s.configPath
+		default:
+			return ""
+		}
+	}
+	ctx := context.Background()
+	stdout := &strings.Builder{}
+
+	s.ctr = di.BuildPreprocessorContainer(ctx, getenv, stdout)
 }
 
 func (s *IntegrationTestSuite) TearDownSuite() {

--- a/service/internal/preprocessor/writer/test_helper.go
+++ b/service/internal/preprocessor/writer/test_helper.go
@@ -113,6 +113,5 @@ preprocessor:
 	if err != nil {
 		panic(err)
 	}
-	os.Setenv("CONFIG_PATH", configPath)
 	return configPath
 }

--- a/service/internal/search/conesearch/test_helpers/test_helpers.go
+++ b/service/internal/search/conesearch/test_helpers/test_helpers.go
@@ -55,7 +55,7 @@ func WriteConfigFile(configPath, config string) error {
 		slog.Error("could not write config file")
 		return err
 	}
-	return os.Setenv("CONFIG_PATH", configPath)
+	return nil
 }
 
 func Migrate(dbFile string, rootPath string) error {

--- a/service/internal/web/routes.go
+++ b/service/internal/web/routes.go
@@ -16,14 +16,13 @@ package web
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/gin-gonic/gin"
 )
 
 func (web *Web) SetupRoutes(r *gin.Engine) {
 	r.Use(gin.Recovery())
-	if os.Getenv("USE_LOGGER") != "" {
+	if web.getenv("USE_LOGGER") != "" {
 		r.Use(gin.Logger())
 	}
 

--- a/service/internal/web/web.go
+++ b/service/internal/web/web.go
@@ -12,12 +12,14 @@ type Web struct {
 	conesearchService *conesearch.ConesearchService
 	metadataService   *metadata.MetadataService
 	config            *config.ServiceConfig
+	getenv            func(string) string
 }
 
 func New(
 	conesearchService *conesearch.ConesearchService,
 	metadataService *metadata.MetadataService,
 	config *config.ServiceConfig,
+	getenv func(string string) string,
 ) (*Web, error) {
 	if conesearchService == nil {
 		return nil, fmt.Errorf("ConesearchService was nil while creating HttpServer")
@@ -25,5 +27,5 @@ func New(
 	if metadataService == nil {
 		return nil, fmt.Errorf("MetadataService was nil while creating HttpServer")
 	}
-	return &Web{conesearchService, metadataService, config}, nil
+	return &Web{conesearchService, metadataService, config, getenv}, nil
 }


### PR DESCRIPTION
This PR makes several changes to improve dependency injection and configuration handling:

1. Modifies the main entry points (`startHttpServer`, `startCatalogIndexer`, `startPreprocessor`) to accept dependencies explicitly via parameters (context, getenv function, stdout writer) instead of relying on global state.

2. Introduces a new `run` function in main.go that handles the core application logic, making it more testable by accepting dependencies as parameters.

3. Updates container builders (`BuildServiceContainer`, `BuildIndexerContainer`, `BuildPreprocessorContainer`) to accept context, getenv, and stdout parameters rather than using os.Getenv/os.Stdout directly.

4. Modifies config loading to use a passed getenv function instead of os.Getenv directly.

5. Updates API and Web server initialization to accept getenv function and use it for configuration instead of direct os.Getenv calls.

6. Adjusts test files to:
   - Pass getenv functions instead of setting environment variables directly
   - Use context and stdout parameters
   - Remove direct os.Getenv calls in test setups

7. Makes error handling more consistent by returning errors from previously void functions.

The changes maintain all existing functionality while making the code more testable and less reliant on global state.