### PR TITLE
feat(57): Test colors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,7 @@
                 golangci-lint
                 sqlite
                 go-migrate-sqlite
+                grc
               ];
 
               env = {
@@ -172,6 +173,30 @@
                 PKG_CONFIG_PATH = "${healpix}/lib/pkgconfig";
                 CGO_CFLAGS = "-I${healpix}/include -I${healpix}/include/healpix_cxx -I${pkgs.cfitsio}/include ";
                 CGO_LDFLAGS = "-L${healpix}/lib -L${pkgs.cfitsio}/lib  -lhealpix_cxx -lcfitsio ";
+                GRC_CONFIG = ''
+                  # Regla para "go test" y "make test"
+                  \b(go test)\b
+                  regexp==== RUN .*
+                  colour=bright_blue
+                  -
+                  regexp=--- PASS: .* (\(\d+\.\d+s\))
+                  colour=green, yellow
+                  -
+                  regexp=^PASS$
+                  colour=bold white on_green
+                  -
+                  regexp=^(ok|FAIL)\s+.*
+                  colour=default, magenta
+                  -
+                  regexp=--- FAIL: .* (\(\d+\.\d+s\))
+                  colour=red, yellow
+                  -
+                  regexp=^FAIL$
+                  colour=bold white on_red
+                  -
+                  regexp=[^\s]+\.go(:\d+)?
+                  colour=cyan
+                '';
               };
 
               scripts.init-healpix.exec = ''

--- a/service/justfile
+++ b/service/justfile
@@ -8,7 +8,10 @@ build:
 	go build -o build/main cmd/main.go
 
 test:
-	go test ./... -race
+	grc go test ./... -race
+
+test-verbose:
+	grc go test -v ./... -race
 
 export CONFIG_PATH := env_var_or_default("CONFIG_PATH", "config.yaml")
 


### PR DESCRIPTION
### Development Tooling Enhancements

#### Changes:
1. **Added `grc` (Generic Colouriser) Support**:
   - Installed `grc` as a new development dependency in the Nix environment
   - Configured color rules for `go test` output to improve readability:
     - Color-coded test results (PASS/FAIL)
     - Highlighted file paths and line numbers
     - Differentiated test execution output

2. **Updated Test Commands**:
   - Modified `test` recipe in Justfile to use `grc` for colored output
   - Added new `test-verbose` recipe with colored verbose test output

3. **Environment Configuration**:
   - Added `GRC_CONFIG` environment variable with custom color rules

#### Impact:
- More visually distinguishable test output
- Easier debugging with color-coded test results
- Consistent colored output across development environments

#### Notes:

This only works in local env, in CI it does not show the colors.

#### Example:

<img width="851" alt="Captura de pantalla 2025-06-10 a la(s) 3 18 38 p m" src="https://github.com/user-attachments/assets/a5645069-2088-4a38-9d97-4d8fdf98ee08" />

