### PR TITLE
perf: use buffered channels to restrict memory usage

### DIFF
--- a/service/config.yaml
+++ b/service/config.yaml
@@ -38,6 +38,7 @@ catalog_indexer:
     type: parquet 
     # path to the output file if type produces a file
     output_file: "vlass_metadata.parquet"
+  channel_size: 50000
 # Configuration file for the web service
 service:
   # Database configuration for the service

--- a/service/internal/catalog_indexer/reader/parquet/parquet_reader.go
+++ b/service/internal/catalog_indexer/reader/parquet/parquet_reader.go
@@ -139,15 +139,14 @@ func (r *ParquetReader[T]) ReadBatch() ([]repository.InputSchema, error) {
 	if err != nil {
 		if err == io.EOF && r.currentReader < len(r.parquetReaders)-1 {
 			// only finished current file, but more files remain
+			r.fileReaders[r.currentReader].Close()
 			r.currentReader += 1
 			return currentRows, nil
 		}
 		if err == io.EOF {
 			// finished reading all files
+			r.fileReaders[r.currentReader].Close()
 			r.currentReader += 1
-			for i := range r.fileReaders {
-				r.fileReaders[i].Close()
-			}
 			return currentRows, err
 		}
 		return nil, err

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -37,6 +37,7 @@ type CatalogIndexerConfig struct {
 	Indexer        *IndexerConfig  `yaml:"indexer"`
 	IndexerWriter  *WriterConfig   `yaml:"indexer_writer"`
 	MetadataWriter *WriterConfig   `yaml:"metadata_writer"`
+	ChannelSize    int             `yaml:"channel_size"`
 }
 
 type PreprocessorConfig struct {


### PR DESCRIPTION
**PR Summary: Improve profiling support and configurability in indexer service**

This PR introduces several enhancements to the xmatch service, focusing on runtime profiling, resource configuration, and code robustness:

### 🧠 Profiling Enhancements

* **CPU and memory profiling support** added behind the `--profile` flag.

  * CPU profile written to `cpu.prof`.
  * Memory profile written to `mem.prof`, with `runtime.GC()` triggered before snapshot.
* Improved error handling when creating profiling output files.
* Changed `flag.FlagSet` to `ExitOnError` and corrected argument parsing with `args[2:]`.

### ⚙️ Configurability and Performance

* Introduced new config parameter: `catalog_indexer.channel_size` (default: `50000`).

  * Enables tuning of channel buffer sizes for reader and writer goroutines.
  * Used to initialize buffered channels in DI container for better throughput and reduced blocking.

### 🧹 Cleanup & Robustness

* Ensures each Parquet file reader is closed after EOF, instead of closing all readers at once.
* Refactored config loading in DI setup for clarity.
