### PR TITLE
feat: add configurable Neowise lightcurve filtering

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,8 +18,9 @@ test-verbose:
 
 export CONFIG_PATH := env_var_or_default("CONFIG_PATH", "service/config.yaml")
 
+[working-directory: 'service']
 run application flags='' $LOG_LEVEL="debug": build
-	./service/build/main {{flags}} {{application}}
+	./build/main {{flags}} {{application}}
 
 clean-build:
 	rm -r service/build

--- a/service/config.yaml
+++ b/service/config.yaml
@@ -41,7 +41,10 @@ service:
     url: "file:dev.db"
   bulk_chunk_size: 500
   max_bulk_concurrency: 4
-  # Configuration for the preprocessor
+  lightcurve_service:
+    neowise:
+      use_cntr_filter: true
+# Configuration for the preprocessor
 preprocessor:
   source:
     # a path to the input file or files

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -112,13 +112,22 @@ type PartitionReaderConfig struct {
 }
 
 type ServiceConfig struct {
-	Database           *DatabaseConfig `yaml:"database"`
-	BulkChunkSize      int             `yaml:"bulk_chunk_size"`
-	MaxBulkConcurrency int             `yaml:"max_bulk_concurrency"`
+	Database                *DatabaseConfig          `yaml:"database"`
+	BulkChunkSize           int                      `yaml:"bulk_chunk_size"`
+	MaxBulkConcurrency      int                      `yaml:"max_bulk_concurrency"`
+	LightcurveServiceConfig *LightcurveServiceConfig `yaml:"lightcurve_service"`
 }
 
 type DatabaseConfig struct {
 	Url string `yaml:"url"`
+}
+
+type LightcurveServiceConfig struct {
+	NeowiseConfig *NeowiseConfig `yaml:"neowise"`
+}
+
+type NeowiseConfig struct {
+	UseCntrFilter bool `yaml:"use_cntr_filter"`
 }
 
 func Load(getEnv func(string) string) (*Config, error) {

--- a/service/internal/di/service_container.go
+++ b/service/internal/di/service_container.go
@@ -138,10 +138,15 @@ func BuildServiceContainer(
 		return service
 	})
 
-	ctr.Singleton(func(conesearchService *conesearch.ConesearchService) *lightcurve.LightcurveService {
+	ctr.Singleton(func(conesearchService *conesearch.ConesearchService, cfg *config.Config) *lightcurve.LightcurveService {
+		lightcurveFilterSlice := []lightcurve.LightcurveFilter{lightcurve.DummyLightcurveFilter}
+		if cfg.Service.LightcurveServiceConfig != nil && cfg.Service.LightcurveServiceConfig.NeowiseConfig.UseCntrFilter {
+			lightcurveFilterSlice = append(lightcurveFilterSlice, neowise.Filter)
+		}
+
 		service, err := lightcurve.New(
 			[]lightcurve.ExternalClient{neowise.NewNeowiseClient()},
-			[]lightcurve.LightcurveFilter{neowise.Filter},
+			lightcurveFilterSlice,
 			conesearchService,
 		)
 		if err != nil {

--- a/service/internal/search/lightcurve/lightcurve_service.go
+++ b/service/internal/search/lightcurve/lightcurve_service.go
@@ -30,6 +30,10 @@ type ConesearchService interface {
 
 type LightcurveFilter func(Lightcurve, []conesearch.MetadataResult) Lightcurve
 
+func DummyLightcurveFilter(l Lightcurve, _ []conesearch.MetadataResult) Lightcurve {
+	return l
+}
+
 type ClientResult struct {
 	Lightcurve Lightcurve
 	Error      error


### PR DESCRIPTION
- Add configuration structure for lightcurve service with Neowise-specific options
- Make Neowise CNTR filter optional via `use_cntr_filter` configuration
- Add dummy lightcurve filter for cases where no filtering is needed
- Update dependency injection to conditionally apply Neowise filter based on config
- Fix justfile working directory and binary path for run command