### PR TITLE
fix: csv reader options applied after source changes

### DIFF
--- a/service/internal/catalog_indexer/source/source.go
+++ b/service/internal/catalog_indexer/source/source.go
@@ -96,6 +96,7 @@ func (src *Source) Next() (io.ReadCloser, error) {
 		return nil, io.EOF
 	}
 	slog.Info("Reading source", "current", src.CurrentSource+1, "total", len(src.Sources))
+	slog.Info("Current source is", "source", src.Sources[src.CurrentSource])
 
 	// In memory source from the source string itself
 	if strings.HasPrefix(src.Sources[src.CurrentSource], "buffer:") {


### PR DESCRIPTION
Fixes an error where after changing the csv file, the options like the comment character are reset, due to initializing a new csv reader.

This PR makes sure to set all options again after creating the new reader.