### PR TITLE
feat: add fits file reader

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -3,12 +3,12 @@ module github.com/dirodriguezm/xmatch/service
 go 1.24.0
 
 require (
+	codeberg.org/astrogo/fitsio v0.4.0
 	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/log v0.4.2
 	github.com/dirodriguezm/healpix v0.0.0-20241017225944-6b9a84e4353c
 	github.com/gin-gonic/gin v1.10.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
-	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0

--- a/service/go.sum
+++ b/service/go.sum
@@ -65,6 +65,8 @@ cloud.google.com/go/storage v1.12.0/go.mod h1:fFLk2dp2oAhDz8QFKwqrjdJvxSp/W2g7ni
 cloud.google.com/go/storage v1.21.0/go.mod h1:XmRlxkgPjlBONznT2dDUU/5XlpU2OjMnKuqnZI01LAA=
 cloud.google.com/go/trace v1.0.0/go.mod h1:4iErSByzxkyHWzzlAj63/Gmjz0NH1ASqhJguHpGcr6A=
 cloud.google.com/go/trace v1.2.0/go.mod h1:Wc8y/uYyOhPy12KEnXG9XGrvfMz5F5SrYecQlbW1rwM=
+codeberg.org/astrogo/fitsio v0.4.0 h1:ATDKD8+cDIi9VJ609JbnPGnJblJPV59iojHGL377Ur0=
+codeberg.org/astrogo/fitsio v0.4.0/go.mod h1:MlK0U74YrpQ6WGly5Zw2vHvu74YtzWhi4fUY1oDDvWY=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20200617204711-c478e41e60e9/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.10/go.mod h1:I5htMbyta491eUxufwwZPQdcKvvgzMB4O9ni41YnIM8=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
@@ -627,8 +629,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
-github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/service/internal/catalog_indexer/reader/csv/csv_reader.go
+++ b/service/internal/catalog_indexer/reader/csv/csv_reader.go
@@ -103,6 +103,8 @@ func (r *CsvReader) Read() ([]repository.InputSchema, error) {
 			return nil, fmt.Errorf("Could not get next source: %w", err)
 		}
 
+		r.currentFileReader.Close()
+		r.currentFileReader = ioReader
 		r.currentReader = csv.NewReader(ioReader)
 	}
 
@@ -161,6 +163,9 @@ func (r *CsvReader) ReadBatch() ([]repository.InputSchema, error) {
 		if nextErr != nil {
 			return rows, nextErr // This error can potentially be EOF, handled by the caller.
 		}
+
+		r.currentFileReader.Close()
+		r.currentFileReader = ioReader
 		r.currentReader = csv.NewReader(ioReader)
 		// We need to apply the options again, since the reader was reset
 		for _, opt := range r.opts {

--- a/service/internal/catalog_indexer/reader/fits/fits_reader.go
+++ b/service/internal/catalog_indexer/reader/fits/fits_reader.go
@@ -1,0 +1,182 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fits_reader
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"codeberg.org/astrogo/fitsio"
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/source"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+)
+
+type FitsReader struct {
+	currentFileReader io.ReadCloser
+	currentFitsRows   *fitsio.Rows
+	currentFitsFile   *fitsio.File
+	src               *source.Source
+	batchSize         int
+}
+
+func NewFitsReader(src *source.Source, opts ...FitsReaderOption) (FitsReader, error) {
+	currentFileReader, err := src.Next()
+	if err != nil {
+		return FitsReader{}, err
+	}
+
+	fits, err := fitsio.Open(currentFileReader)
+	if err != nil {
+		return FitsReader{}, err
+	}
+	table := fits.HDU(1).(*fitsio.Table)
+	rows, err := table.Read(0, table.NumRows())
+	if err != nil {
+		return FitsReader{}, err
+	}
+
+	r := FitsReader{
+		currentFileReader: currentFileReader,
+		currentFitsRows:   rows,
+		currentFitsFile:   fits,
+		src:               src,
+		batchSize:         1,
+	}
+
+	for _, opt := range opts {
+		r = opt(r)
+	}
+
+	return r, nil
+}
+
+func (r *FitsReader) Read() ([]repository.InputSchema, error) {
+	panic("Not implemented")
+}
+
+func (r *FitsReader) ReadBatch() ([]repository.InputSchema, error) {
+	rows := make([]repository.InputSchema, 0, r.batchSize)
+
+	currentRows, err := r.ReadBatchSingleFile(r.currentFitsRows, r.batchSize, r.src.CatalogName)
+
+	// If the error is EOF, we get the next reader from the Source.
+	// And if there is no next reader, we return the rows we have so far.
+	if err == io.EOF {
+		rows = append(rows, currentRows...)
+
+		err = r.closeResources()
+		if err != nil {
+			return rows, err
+		}
+
+		err = r.switchToNewFile()
+		if err != nil {
+			return rows, err
+		}
+
+		return rows, nil
+	}
+
+	// If the error is not EOF, it's a real error.
+	if err != nil {
+		return nil, fmt.Errorf("could not read batch from csv: %w", err)
+	}
+
+	// Read batch successfully and more to read
+	rows = append(rows, currentRows...)
+	return rows, nil
+}
+
+func (r *FitsReader) closeResources() error {
+	err := r.currentFitsRows.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close FITS rows: %w", err)
+	}
+
+	err = r.currentFitsFile.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close FITS file: %w", err)
+	}
+
+	err = r.currentFileReader.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close file reader: %w", err)
+	}
+
+	return nil
+}
+
+func (r *FitsReader) switchToNewFile() error {
+	ioReader, err := r.src.Next()
+	if err != nil {
+		return err // This error can potentially be EOF, handled by the caller.
+	}
+	r.currentFileReader = ioReader
+
+	r.currentFitsFile, err = fitsio.Open(ioReader)
+	if err != nil {
+		return err
+	}
+
+	table := r.currentFitsFile.HDU(0).(*fitsio.Table)
+	r.currentFitsRows, err = table.Read(0, table.NumRows())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *FitsReader) ReadBatchSingleFile(rowIterator *fitsio.Rows, size int, name string) ([]repository.InputSchema, error) {
+	rows := make([]repository.InputSchema, 0, size)
+	for range size {
+		hasNext := rowIterator.Next()
+		if !hasNext {
+			return rows, io.EOF
+		}
+
+		row := r.createInputSchema(name, rowIterator)
+		rows = append(rows, row)
+	}
+
+	return rows, nil
+}
+
+func (r *FitsReader) createInputSchema(name string, rowIterator *fitsio.Rows) repository.InputSchema {
+	switch name {
+	case "allwise":
+		schema := repository.AllwiseInputSchema{}
+		err := rowIterator.Scan(&schema)
+		if err != nil {
+			panic(err)
+		}
+		return schema
+	default:
+		schema := TestSchema{}
+		err := rowIterator.Scan(&schema)
+		if err != nil {
+			panic(err)
+		}
+		return schema
+	}
+}
+
+func (r *FitsReader) Close() error {
+	return errors.Join(
+		r.currentFitsRows.Close(),
+		r.currentFitsFile.Close(),
+	)
+}

--- a/service/internal/catalog_indexer/reader/fits/fits_reader_option.go
+++ b/service/internal/catalog_indexer/reader/fits/fits_reader_option.go
@@ -1,0 +1,13 @@
+package fits_reader
+
+type FitsReaderOption func(r FitsReader) FitsReader
+
+func WithBatchSize(size int) FitsReaderOption {
+	return func(r FitsReader) FitsReader {
+		if size <= 0 {
+			size = 1
+		}
+		r.batchSize = size
+		return r
+	}
+}

--- a/service/internal/catalog_indexer/reader/fits/fits_reader_test.go
+++ b/service/internal/catalog_indexer/reader/fits/fits_reader_test.go
@@ -1,0 +1,318 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fits_reader
+
+import (
+	"testing"
+
+	"github.com/dirodriguezm/xmatch/service/internal/catalog_indexer/source"
+	"github.com/dirodriguezm/xmatch/service/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBatch(t *testing.T) {
+	testData := []map[string]any{
+		{
+			"col1": "hola",
+			"col2": 18,
+		},
+		{
+			"col1": "adios",
+			"col2": 99,
+		},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestRead.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestRead.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	fitsReader, err := NewFitsReader(src, WithBatchSize(2))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithDifferentDataTypes(t *testing.T) {
+	testData := []map[string]any{
+		{
+			"string_col": "test1",
+			"int_col":    int32(42),
+			"float_col":  3.14159,
+			"bool_col":   true,
+			"int64_col":  int64(9999999999),
+		},
+		{
+			"string_col": "test2",
+			"int_col":    int32(-100),
+			"float_col":  -2.71828,
+			"bool_col":   false,
+			"int64_col":  int64(-9999999999),
+		},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithDifferentDataTypes.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithDifferentDataTypes.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	fitsReader, err := NewFitsReader(src, WithBatchSize(2))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithEmptyFile(t *testing.T) {
+	testData := []map[string]any{}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithEmptyFile.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithEmptyFile.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	fitsReader, err := NewFitsReader(src, WithBatchSize(2))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.EqualError(t, err, "EOF")
+	require.Equal(t, 0, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithLargeBatchSize(t *testing.T) {
+	testData := []map[string]any{
+		{"col1": "row1", "col2": 1},
+		{"col1": "row2", "col2": 2},
+		{"col1": "row3", "col2": 3},
+		{"col1": "row4", "col2": 4},
+		{"col1": "row5", "col2": 5},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithLargeBatchSize.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithLargeBatchSize.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	// Test with batch size larger than available rows
+	fitsReader, err := NewFitsReader(src, WithBatchSize(10))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.EqualError(t, err, "EOF")
+	require.Equal(t, 5, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithSmallBatchSize(t *testing.T) {
+	testData := []map[string]any{
+		{"col1": "row1", "col2": 1},
+		{"col1": "row2", "col2": 2},
+		{"col1": "row3", "col2": 3},
+		{"col1": "row4", "col2": 4},
+		{"col1": "row5", "col2": 5},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithSmallBatchSize.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithSmallBatchSize.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	// Test with batch size smaller than available rows
+	fitsReader, err := NewFitsReader(src, WithBatchSize(2))
+	require.NoError(t, err)
+
+	// First batch
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rows))
+
+	// Second batch
+	rows, err = fitsReader.ReadBatch()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rows))
+
+	// Third batch (remaining 1 row)
+	rows, err = fitsReader.ReadBatch()
+	require.EqualError(t, err, "EOF")
+	require.Equal(t, 1, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithNilValues(t *testing.T) {
+	testData := []map[string]any{
+		{
+			"col1":         "row1",
+			"col2":         1,
+			"nullable_col": nil,
+		},
+		{
+			"col1":         "row2",
+			"col2":         2,
+			"nullable_col": "not null",
+		},
+		{
+			"col1":         "row3",
+			"col2":         3,
+			"nullable_col": nil,
+		},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithNilValues.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithNilValues.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	fitsReader, err := NewFitsReader(src, WithBatchSize(3))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+	require.Equal(t, 3, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithDefaultBatchSize(t *testing.T) {
+	testData := []map[string]any{
+		{"col1": "row1", "col2": 1},
+		{"col1": "row2", "col2": 2},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithDefaultBatchSize.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithDefaultBatchSize.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	// Test without specifying batch size (should use default)
+	fitsReader, err := NewFitsReader(src)
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+	// Default batch size should be 1 based on WithBatchSize logic
+	require.Equal(t, 1, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithInvalidBatchSize(t *testing.T) {
+	testData := []map[string]any{
+		{"col1": "row1", "col2": 1},
+		{"col1": "row2", "col2": 2},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithInvalidBatchSize.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithInvalidBatchSize.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	// Test with zero batch size (should be normalized to 1)
+	fitsReader, err := NewFitsReader(src, WithBatchSize(0))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}
+
+func TestReadBatchWithNegativeBatchSize(t *testing.T) {
+	testData := []map[string]any{
+		{"col1": "row1", "col2": 1},
+		{"col1": "row2", "col2": 2},
+	}
+
+	writeFitsFile(t, "/tmp/fits_reader_test_TestReadBatchWithNegativeBatchSize.fits", testData)
+
+	cfg := config.SourceConfig{
+		Url:         "file:/tmp/fits_reader_test_TestReadBatchWithNegativeBatchSize.fits",
+		Type:        "fits",
+		CatalogName: "test",
+	}
+	src, err := source.NewSource(cfg)
+	require.NoError(t, err)
+
+	// Test with negative batch size (should be normalized to 1)
+	fitsReader, err := NewFitsReader(src, WithBatchSize(-5))
+	require.NoError(t, err)
+
+	rows, err := fitsReader.ReadBatch()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rows))
+
+	err = fitsReader.Close()
+	require.NoError(t, err)
+}

--- a/service/internal/catalog_indexer/reader/fits/test_helpers.go
+++ b/service/internal/catalog_indexer/reader/fits/test_helpers.go
@@ -1,0 +1,250 @@
+// Copyright 2024-2025 Diego Rodriguez Mancini
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fits_reader
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"codeberg.org/astrogo/fitsio"
+	"github.com/dirodriguezm/xmatch/service/internal/repository"
+)
+
+func writeFitsFile(t *testing.T, filename string, rows []map[string]any) {
+	t.Helper()
+
+	t.Log("Creating file", filename)
+	f, err := os.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	t.Log("Created file", filename)
+
+	t.Log("Creating fits file")
+	fitsFile, err := fitsio.Create(f)
+	if err != nil {
+		t.Fatal("Could not create fits file")
+	}
+	defer fitsFile.Close()
+	t.Log("Created fits file")
+
+	t.Log("Creating primaryHDU")
+	phdu, err := fitsio.NewPrimaryHDU(nil)
+	if err != nil {
+		t.Fatal("Could not create primaryHDU %w", err)
+	}
+	t.Log("Created primaryHDU")
+
+	t.Log("Writing primaryHDU to file")
+	if err := fitsFile.Write(phdu); err != nil {
+		t.Fatal("Could not write primaryHDU to file %w", err)
+	}
+	t.Log("Wrote primaryHDU to file")
+
+	// create table
+	t.Log("Creating table")
+	fitsTable, err := CreateFitsTable(rows)
+	if err != nil {
+		t.Fatal("Could not create table %w", err)
+	}
+	defer fitsTable.Close()
+	t.Log("Created table")
+
+	// Write the table to the file
+	t.Log("Writing table to file")
+	err = fitsFile.Write(fitsTable)
+	if err != nil {
+		t.Fatal("Could not write table to file %w", err)
+	}
+	t.Log("Wrote table to file")
+
+}
+
+func CreateFitsTable(data []map[string]any) (*fitsio.Table, error) {
+	// create columns using the keys of the first map
+	// the type of the column is determined by the type of the value
+	columns, err := createColumns(data)
+	if err != nil {
+		return nil, err
+	}
+
+	data = cleanData(data, columns)
+
+	// create table from columns
+	table, err := fitsio.NewTable("results", columns, fitsio.BINARY_TBL)
+	if err != nil {
+		return nil, err
+	}
+
+	// populate the table
+	rslice := reflect.ValueOf(data)
+	for i := range rslice.Len() {
+		row := rslice.Index(i).Addr()
+		err := table.Write(row.Interface())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	nrows := table.NumRows()
+	if nrows != int64(len(data)) {
+		return nil, fmt.Errorf("Error creating table: number of rows written (%d) does not match number of rows in data (%d)", nrows, len(data))
+	}
+
+	return table, nil
+}
+
+func createColumns(data []map[string]any) ([]fitsio.Column, error) {
+	if len(data) == 0 {
+		return []fitsio.Column{}, nil
+	}
+
+	columns := make([]fitsio.Column, 0, len(data[0]))
+	keys := make([]string, 0, len(data[0]))
+	for key := range data[0] {
+		keys = append(keys, key)
+	}
+	// sort the keys to ensure consistent column order
+	sort.Strings(keys)
+	var format string
+	for _, key := range keys {
+		for i := range data {
+			if data[i][key] == nil {
+				continue
+			}
+			value := data[i][key]
+			format = getFormat(value)
+			if format == "" {
+				return nil, fmt.Errorf("Error creating columns: unsupported type %T for key %s", value, key)
+			}
+			columns = append(columns, fitsio.Column{
+				Name:   key,
+				Format: format,
+			})
+			break
+		}
+	}
+	return columns, nil
+}
+
+func getFormat(value any) string {
+	switch value := value.(type) {
+	case int16:
+		return "I" // 16-bit integer
+	case int32:
+		return "J" // 32-bit integer
+	case int:
+		return "K" // 64-bit integer
+	case int64:
+		return "K" // 64-bit integer
+	case float32:
+		return "E" // 32-bit floating point
+	case float64:
+		return "D" // 64-bit floating point
+	case string:
+		stringLength := len(value)
+		return fmt.Sprintf("%dA", stringLength) // Character string with length
+	case bool:
+		return "L" // logical
+	default:
+		return ""
+	}
+}
+
+func cleanData(data []map[string]any, columns []fitsio.Column) []map[string]any {
+	if len(data) == 0 {
+		return []map[string]any{}
+	}
+
+	cleanedData := make([]map[string]any, len(data))
+	for i := range data {
+		cleanedData[i] = make(map[string]any, len(columns))
+	}
+	keys := make([]string, 0, len(data[0]))
+	for key := range data[0] {
+		keys = append(keys, key)
+	}
+	// sort the keys to ensure consistent column order
+	sort.Strings(keys)
+	for _, key := range keys {
+		for i := range data {
+			if data[i][key] != nil {
+				cleanedData[i][key] = data[i][key]
+				continue
+			}
+			for j := range columns {
+				if columns[j].Name != key {
+					continue
+				}
+				format := columns[j].Format
+				cleanedData[i][key] = getZeroValueForFormat(format)
+			}
+		}
+	}
+	return cleanedData
+}
+
+func getZeroValueForFormat(format string) any {
+	if strings.Contains(format, "A") {
+		format = "A"
+	}
+	switch format {
+	case "I":
+		return int16(0)
+	case "J":
+		return int32(0)
+	case "K":
+		return int64(0)
+	case "E":
+		return float32(0)
+	case "D":
+		return float64(0)
+	case "A":
+		return ""
+	case "L":
+		return false
+	default:
+		return nil
+	}
+}
+
+type TestSchema struct {
+	Oid string
+	Ra  float64
+	Dec float64
+}
+
+func (t TestSchema) FillMastercat(dst *repository.Mastercat, ipix int64) {
+	dst.ID = t.Oid
+	dst.Ra = t.Ra
+	dst.Dec = t.Dec
+	dst.Cat = "test"
+	dst.Ipix = ipix
+}
+
+func (t TestSchema) FillMetadata(dst repository.Metadata) {}
+
+func (t TestSchema) GetCoordinates() (float64, float64) {
+	return t.Ra, t.Dec
+}
+
+func (t TestSchema) GetId() string {
+	return t.Oid
+}

--- a/service/internal/catalog_indexer/source/source.go
+++ b/service/internal/catalog_indexer/source/source.go
@@ -116,7 +116,7 @@ func (src *Source) Next() (io.ReadCloser, error) {
 }
 
 func validateSourceType(stype string) bool {
-	allowedTypes := []string{"csv", "parquet"}
+	allowedTypes := []string{"csv", "parquet", "fits"}
 	return slices.Contains(allowedTypes, stype)
 }
 


### PR DESCRIPTION
## PR Summary: FITS File Reader Implementation

### Overview
This PR adds support for reading FITS (Flexible Image Transport System) files to the catalog indexer, expanding the system's capability to handle astronomical data formats.

### Changes

#### 1. **Dependencies Added**
- Added `codeberg.org/astrogo/fitsio v0.4.0` for FITS file parsing


#### 2. **New FITS Reader Implementation**
- **`fits_reader.go`**: Complete FITS reader implementation with:
  - Batch reading support with configurable batch size
  - Proper resource management (closing files, rows, and FITS handles)
  - Support for multiple FITS files in sequence
  - Integration with existing `InputSchema` interface
- **`fits_reader_option.go`**: Configuration options for batch size
- **`fits_reader_test.go`**: Comprehensive test suite covering:
  - Basic batch reading
  - Different data types (strings, integers, floats, booleans)
  - Edge cases (empty files, large/small batch sizes, nil values)
  - Invalid batch size handling
- **`test_helpers.go`**: Test utilities for creating FITS files programmatically

#### 3. **CSV Reader Fix**
- Fixed resource management in CSV reader to properly close file readers when switching between files in `csv_reader.go`

#### 4. **Source Type Validation Update**
- Updated `source.go` to include "fits" as a valid source type alongside "csv" and "parquet"
