### PR TITLE
fix: add index to bulk conesearch result to map input coordinates

### DIFF
--- a/service/internal/search/conesearch/conesearch.go
+++ b/service/internal/search/conesearch/conesearch.go
@@ -26,10 +26,14 @@ import (
 	"github.com/dirodriguezm/xmatch/service/internal/assertions"
 	"github.com/dirodriguezm/xmatch/service/internal/repository"
 	"github.com/dirodriguezm/xmatch/service/internal/search/knn"
-	"github.com/dirodriguezm/xmatch/service/internal/utils"
 
 	"github.com/dirodriguezm/healpix"
 )
+
+type indexedResult struct {
+	index  int
+	result knn.KnnResult[repository.Mastercat]
+}
 
 type Repository interface {
 	FindObjects(context.Context, []int64) ([]repository.Mastercat, error)
@@ -136,7 +140,7 @@ func (c *ConesearchService) Conesearch(ra, dec, radius float64, nneighbor int, c
 		objects = append(objects, objs...)
 	}
 
-	return ResultFromKnn(knn.NearestNeighborSearch(objects, ra, dec, radius, nneighbor)), nil
+	return ResultFromKnn(knn.NearestNeighborSearch(objects, ra, dec, radius, nneighbor), 0), nil
 }
 
 func (c *ConesearchService) FindMetadataByConesearch(
@@ -189,7 +193,7 @@ func (c *ConesearchService) BulkConesearch(
 
 	radius_radians := arcsecToRadians(radius)
 	numChunks := (len(ra) + chunkSize - 1) / chunkSize
-	resultsChan := make(chan knn.KnnResult[repository.Mastercat], numChunks)
+	resultsChan := make(chan indexedResult, numChunks)
 	errChan := make(chan error, numChunks)
 	var wg sync.WaitGroup
 
@@ -203,7 +207,7 @@ func (c *ConesearchService) BulkConesearch(
 			chunkRa := ra[i:end]
 			chunkDec := dec[i:end]
 
-			go func(chunkRa, chunkDec []float64) {
+			go func(chunkRa, chunkDec []float64, baseIndex int) {
 				sem <- struct{}{}
 
 				defer func() {
@@ -218,12 +222,16 @@ func (c *ConesearchService) BulkConesearch(
 					objs, err := c.getObjects(pixelList, catalog)
 					if err != nil {
 						errChan <- err
+						break
 					}
 
-					resultsChan <- knn.NearestNeighborSearch(objs, chunkRa[j], chunkDec[j], radius, nneighbor)
+					resultsChan <- indexedResult{
+						index:  baseIndex + j,
+						result: knn.NearestNeighborSearch(objs, chunkRa[j], chunkDec[j], radius, nneighbor),
+					}
 				}
 
-			}(chunkRa, chunkDec)
+			}(chunkRa, chunkDec, i)
 		}
 	}
 
@@ -233,21 +241,34 @@ func (c *ConesearchService) BulkConesearch(
 		close(errChan)
 	}()
 
-	allObjects := make([]MastercatResult, 0)
-	for result := range resultsChan {
-		allObjects = append(allObjects, ResultFromKnn(result)...)
+	resultsByIndex := make([][]MastercatResult, len(ra))
+	for indexed := range resultsChan {
+		resultsByIndex[indexed.index] = ResultFromKnn(indexed.result, indexed.index)
 	}
 	for err := range errChan {
 		return nil, err
 	}
 
 	uniqueObjects := make([]MastercatResult, 0)
-	ids := utils.Set{}
-	for i := range allObjects {
-		for j := range allObjects[i].Data {
-			if !ids.Contains(allObjects[i].Data[j].ID) {
-				uniqueObjects = append(uniqueObjects, allObjects[i])
-				ids.Add(allObjects[i].Data[j].ID)
+	seenIDs := make(map[int]map[string]bool)
+	for i := range resultsByIndex {
+		if resultsByIndex[i] == nil {
+			resultsByIndex[i] = []MastercatResult{}
+		}
+		if seenIDs[i] == nil {
+			seenIDs[i] = make(map[string]bool)
+		}
+		for _, mastercatResult := range resultsByIndex[i] {
+			for j := range mastercatResult.Data {
+				id := mastercatResult.Data[j].ID
+				if !seenIDs[i][id] {
+					seenIDs[i][id] = true
+					uniqueObjects = append(uniqueObjects, MastercatResult{
+						Catalog: mastercatResult.Catalog,
+						Data:    []MastercatExtended{mastercatResult.Data[j]},
+						Index:   i,
+					})
+				}
 			}
 		}
 	}

--- a/service/internal/search/conesearch/conesearch_integration_test.go
+++ b/service/internal/search/conesearch/conesearch_integration_test.go
@@ -283,14 +283,83 @@ func TestBulkConesearch(t *testing.T) {
 			t.Error(err)
 		}
 
-		require.Len(t, tc.expected, len(result), "testCase: %v | result: %v", tc, result)
+		foundIDs := make(map[string]bool)
 		for i := range result {
 			for j := range result[i].Data {
 				id := result[i].Data[j].ID
 				require.Contains(t, tc.expected, id, "testCase: %v | result: %v", tc, result)
+				foundIDs[id] = true
 			}
 		}
+		for _, expectedID := range tc.expected {
+			require.True(t, foundIDs[expectedID], "expected ID %s not found in result for testCase: %v", expectedID, tc)
+		}
 	}
+
+	// test that coordinates with no matches are properly handled
+	t.Run("coordinates with no matches return empty results", func(t *testing.T) {
+		noMatchResult, err := service.BulkConesearch(
+			[]float64{100, 200}, // coordinates with no objects nearby
+			[]float64{50, 60},
+			1,
+			10,
+			"all",
+			1,
+			1,
+		)
+		require.NoError(t, err)
+		require.Len(t, noMatchResult, 0, "expected no matches for coordinates with no nearby objects, got: %v", noMatchResult)
+	})
+
+	// test that Index field is correctly set
+	t.Run("index field is correctly set for matched coordinates", func(t *testing.T) {
+		multiMatchResult, err := service.BulkConesearch(
+			[]float64{0, 10}, // first matches A, second matches B
+			[]float64{0, 10},
+			1,
+			10,
+			"all",
+			1,
+			1,
+		)
+		require.NoError(t, err)
+		require.Len(t, multiMatchResult, 2, "expected 2 results, got: %v", multiMatchResult)
+
+		indexMap := make(map[int][]string)
+		for _, r := range multiMatchResult {
+			for _, d := range r.Data {
+				indexMap[r.Index] = append(indexMap[r.Index], d.ID)
+			}
+		}
+		require.Contains(t, indexMap[0], "A", "index 0 should contain ID A")
+		require.Contains(t, indexMap[1], "B", "index 1 should contain ID B")
+	})
+
+	// test that non-matching coordinates in the middle are handled correctly
+	t.Run("non-matching coordinates in the middle preserve index correctness", func(t *testing.T) {
+		middleNoMatchResult, err := service.BulkConesearch(
+			[]float64{0, 50, 10, 60},
+			[]float64{0, 50, 10, 60},
+			1,
+			10,
+			"all",
+			1,
+			1,
+		)
+		require.NoError(t, err)
+		require.Len(t, middleNoMatchResult, 2, "expected 2 results, got: %v", middleNoMatchResult)
+
+		indexMap := make(map[int][]string)
+		for _, r := range middleNoMatchResult {
+			for _, d := range r.Data {
+				indexMap[r.Index] = append(indexMap[r.Index], d.ID)
+			}
+		}
+		require.Contains(t, indexMap[0], "A", "index 0 should contain ID A")
+		require.Contains(t, indexMap[2], "B", "index 2 should contain ID B")
+		require.NotContains(t, indexMap, 1, "index 1 should have no matches")
+		require.NotContains(t, indexMap, 3, "index 3 should have no matches")
+	})
 
 	CleanDB(t, repo)
 }

--- a/service/internal/search/conesearch/conesearch_test.go
+++ b/service/internal/search/conesearch/conesearch_test.go
@@ -131,6 +131,19 @@ func TestBulkConesearch(t *testing.T) {
 	}
 }
 
+func TestBulkConesearch_WithRepositoryError(t *testing.T) {
+	repo := &MockRepository{}
+	repo.On("FindObjects", mock.Anything, mock.Anything).Return(nil, errors.New("repository error"))
+	catalogs := []repository.Catalog{{Name: "vlass", Nside: 18}}
+	service, err := NewConesearchService(WithScheme(healpix.Nest), WithRepository(repo), WithCatalogs(catalogs))
+	require.NoError(t, err)
+
+	_, err = service.BulkConesearch([]float64{1, 10}, []float64{1, 10}, 1, 100, "all", 2, 1)
+	repo.AssertExpectations(t)
+	require.Error(t, err)
+	require.Equal(t, "repository error", err.Error())
+}
+
 func TestConesearch_WithMetadata(t *testing.T) {
 	objects := []repository.GetAllwiseFromPixelsRow{
 		{ID: "A", Ra: 1, Dec: 1},

--- a/service/internal/search/conesearch/mastercat_result.go
+++ b/service/internal/search/conesearch/mastercat_result.go
@@ -13,9 +13,10 @@ type MastercatExtended struct {
 type MastercatResult struct {
 	Catalog string              `json:"catalog"`
 	Data    []MastercatExtended `json:"data"`
+	Index   int                 `json:"index"`
 }
 
-func ResultFromKnn(objs knn.KnnResult[repository.Mastercat]) []MastercatResult {
+func ResultFromKnn(objs knn.KnnResult[repository.Mastercat], index int) []MastercatResult {
 	result := make([]MastercatResult, 0)
 	grouped := make(map[string][]MastercatExtended)
 	for i, m := range objs.Data {
@@ -25,7 +26,7 @@ func ResultFromKnn(objs knn.KnnResult[repository.Mastercat]) []MastercatResult {
 		})
 	}
 	for catalog, data := range grouped {
-		result = append(result, MastercatResult{Catalog: catalog, Data: data})
+		result = append(result, MastercatResult{Catalog: catalog, Data: data, Index: index})
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

Fix bulk conesearch response to properly map results back to input coordinates.

## Problem

The bulk conesearch endpoint returned results without preserving the correspondence between matched objects and their input coordinate indices. This caused issues when:
- Some coordinates had no matches (they were silently dropped)
- Duplicate IDs across different coordinates caused data loss
- There was no way to determine which input coordinate matched a given result

## Changes

- Added `Index` field to `MastercatResult` to track which input coordinate produced each result
- Refactored `BulkConesearch` to use indexed results and preserve index mapping
- Improved deduplication logic to handle duplicate IDs per-coordinate rather than globally
- Added integration tests for edge cases (no matches, middle coordinates without matches)

