### PR TITLE
feat: add catalog filter to lightcurve search

### DIFF
--- a/service/internal/api/lightcurve_handlers.go
+++ b/service/internal/api/lightcurve_handlers.go
@@ -16,6 +16,7 @@ import (
 //	@Param			ra			query		string	true	"Right Ascension coordinate"
 //	@Param			dec			query		string	true	"Declination coordinate"
 //	@Param			radius		query		string	true	"Search radius in arcseconds"
+//	@Param			catalog		query		string	false	"Catalog to query (all, ztf, neowise, allwise)"
 //	@Param			nneighbor	query		string	false	"Number of neighbors to return (default: 1)"
 //	@Success		200			{object}	LightcurveResponse
 //	@Failure		400			{string}	string
@@ -25,6 +26,7 @@ func (api *API) Lightcurve(c *gin.Context) {
 	ra := c.Query("ra")
 	dec := c.Query("dec")
 	radius := c.Query("radius")
+	catalog := c.DefaultQuery("catalog", "all")
 	nneighbor := c.DefaultQuery("nneighbor", "1")
 
 	parsedRa, err := parseRa(ra)
@@ -47,7 +49,12 @@ func (api *API) Lightcurve(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, err)
 		return
 	}
-	lightcurve, err := api.lightcurveService.GetLightcurve(parsedRa, parsedDec, parsedRadius, parsedNneighbor)
+	parsedCatalog, err := parseLightcurveCatalog(catalog)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, err)
+		return
+	}
+	lightcurve, err := api.lightcurveService.GetLightcurve(parsedRa, parsedDec, parsedRadius, parsedNneighbor, parsedCatalog)
 	if err != nil {
 		c.Error(err)
 		c.JSON(http.StatusInternalServerError, "Could not fetch lightcurve")

--- a/service/internal/api/parser.go
+++ b/service/internal/api/parser.go
@@ -16,7 +16,9 @@ package api
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 )
 
 type ParseError struct {
@@ -69,4 +71,22 @@ func parseNneighbor(nneighbor string) (int, error) {
 		return -999, NewParseError(nneighbor, "nneighbor", "Could not parse int.")
 	}
 	return parsedNneighbor, nil
+}
+
+func parseLightcurveCatalog(catalog string) (string, error) {
+	normalizedCatalog := strings.ToLower(strings.TrimSpace(catalog))
+	if normalizedCatalog == "" {
+		return "all", nil
+	}
+
+	availableCatalogs := []string{"all", "ztf", "neowise", "allwise"}
+	if !slices.Contains(availableCatalogs, normalizedCatalog) {
+		return "", NewParseError(catalog, "catalog", "Catalog must be one of all, ztf, neowise, allwise.")
+	}
+
+	if normalizedCatalog == "allwise" {
+		return "neowise", nil
+	}
+
+	return normalizedCatalog, nil
 }

--- a/service/internal/api/parser_test.go
+++ b/service/internal/api/parser_test.go
@@ -81,3 +81,24 @@ func TestNneighborValidation(t *testing.T) {
 		require.Equal(t, expectedResult, result)
 	}
 }
+
+func TestLightcurveCatalogValidation(t *testing.T) {
+	testCases := map[string]string{
+		"":          "all",
+		"all":       "all",
+		"ztf":       "ztf",
+		"neowise":   "neowise",
+		"allwise":   "neowise",
+		"ALLWISE":   "neowise",
+		" NeOWISE ": "neowise",
+	}
+
+	for catalog, expectedCatalog := range testCases {
+		result, err := parseLightcurveCatalog(catalog)
+		require.NoError(t, err)
+		require.Equal(t, expectedCatalog, result)
+	}
+
+	_, err := parseLightcurveCatalog("gaia")
+	require.Error(t, err)
+}

--- a/service/internal/app/api.go
+++ b/service/internal/app/api.go
@@ -109,21 +109,21 @@ func MetadataService(repo conesearch.Repository) (*metadata.MetadataService, err
 }
 
 func LightcurveService(cfg config.Config, conesearchService *conesearch.ConesearchService) (*lightcurve.LightcurveService, error) {
-	externalClients := []lightcurve.ExternalClient{neowise.NewNeowiseClient(), ztfdr.NewZtfDrClient()}
-	lightcurveFilterSlice := make([]lightcurve.LightcurveFilter, 0)
+	neowiseFilter := lightcurve.DummyLightcurveFilter
 	if cfg.Service.LightcurveServiceConfig.NeowiseConfig.UseIdFilter || cfg.Service.LightcurveServiceConfig.NeowiseConfig.UseCntrFilter {
-		lightcurveFilterSlice = append(lightcurveFilterSlice, neowise.Filter)
+		neowiseFilter = neowise.Filter
 	}
+	ztfFilter := lightcurve.DummyLightcurveFilter
 	if cfg.Service.LightcurveServiceConfig.ZtfDrConfig.UseIdFilter {
-		lightcurveFilterSlice = append(lightcurveFilterSlice, ztfdr.Filter)
+		ztfFilter = ztfdr.Filter
 	}
-	if len(lightcurveFilterSlice) == 0 {
-		lightcurveFilterSlice = append(lightcurveFilterSlice, lightcurve.DummyLightcurveFilter)
+	sources := []lightcurve.Source{
+		{Catalog: "neowise", Client: neowise.NewNeowiseClient(), Filter: neowiseFilter},
+		{Catalog: "ztf", Client: ztfdr.NewZtfDrClient(), Filter: ztfFilter},
 	}
 
 	service, err := lightcurve.New(
-		externalClients,
-		lightcurveFilterSlice,
+		sources,
 		conesearchService,
 	)
 	if err != nil {

--- a/service/internal/app/api_test.go
+++ b/service/internal/app/api_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/dirodriguezm/xmatch/service/internal/config"
 	"github.com/dirodriguezm/xmatch/service/internal/search/conesearch"
+	"github.com/dirodriguezm/xmatch/service/internal/search/lightcurve"
+	"github.com/dirodriguezm/xmatch/service/internal/search/lightcurve/ztfdr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,8 +23,11 @@ func TestLightcurveService_AlwaysAddsZtfDrClient(t *testing.T) {
 
 	service, err := LightcurveService(cfg, &conesearch.ConesearchService{})
 	require.NoError(t, err)
-	require.Equal(t, 2, reflect.ValueOf(service).Elem().FieldByName("externalClients").Len())
-	require.Equal(t, 1, reflect.ValueOf(service).Elem().FieldByName("lightcurveFilters").Len())
+
+	sources := reflect.ValueOf(service).Elem().FieldByName("sources")
+	require.Equal(t, 2, sources.Len())
+	require.Equal(t, "ztf", sources.Index(1).FieldByName("Catalog").String())
+	require.Equal(t, reflect.ValueOf(lightcurve.DummyLightcurveFilter).Pointer(), sources.Index(1).FieldByName("Filter").Pointer())
 }
 
 func TestLightcurveService_AddsZtfDrFilterWhenEnabled(t *testing.T) {
@@ -37,6 +42,9 @@ func TestLightcurveService_AddsZtfDrFilterWhenEnabled(t *testing.T) {
 
 	service, err := LightcurveService(cfg, &conesearch.ConesearchService{})
 	require.NoError(t, err)
-	require.Equal(t, 2, reflect.ValueOf(service).Elem().FieldByName("externalClients").Len())
-	require.Equal(t, 1, reflect.ValueOf(service).Elem().FieldByName("lightcurveFilters").Len())
+
+	sources := reflect.ValueOf(service).Elem().FieldByName("sources")
+	require.Equal(t, 2, sources.Len())
+	require.Equal(t, "ztf", sources.Index(1).FieldByName("Catalog").String())
+	require.Equal(t, reflect.ValueOf(ztfdr.Filter).Pointer(), sources.Index(1).FieldByName("Filter").Pointer())
 }

--- a/service/internal/search/lightcurve/lightcurve_service.go
+++ b/service/internal/search/lightcurve/lightcurve_service.go
@@ -15,6 +15,7 @@ package lightcurve
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/dirodriguezm/xmatch/service/internal/search/conesearch"
@@ -36,30 +37,41 @@ func DummyLightcurveFilter(l Lightcurve, _ []conesearch.MetadataResult) Lightcur
 
 type ClientResult struct {
 	Lightcurve Lightcurve
+	Catalog    string
+	Filter     LightcurveFilter
 	Error      error
 }
 
+type Source struct {
+	Catalog string
+	Client  ExternalClient
+	Filter  LightcurveFilter
+}
+
 type LightcurveService struct {
-	externalClients   []ExternalClient
-	lightcurveFilters []LightcurveFilter
+	sources           []Source
 	conesearchService ConesearchService
 }
 
 func New(
-	externalClients []ExternalClient,
-	lightcurveFilters []LightcurveFilter,
+	sources []Source,
 	conesearchService ConesearchService,
 ) (*LightcurveService, error) {
 	if conesearchService == nil {
 		return nil, fmt.Errorf("conesearchService was nil while creating LightcurveService")
 	}
-	if len(externalClients) == 0 {
-		return nil, fmt.Errorf("externalClients was empty while creating LightcurveService")
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("sources was empty while creating LightcurveService")
 	}
-	if len(lightcurveFilters) == 0 {
-		return nil, fmt.Errorf("lightcurveFilters was empty while creating LightcurveService")
+	for i := range sources {
+		if sources[i].Client == nil {
+			return nil, fmt.Errorf("source client was nil while creating LightcurveService")
+		}
+		if sources[i].Filter == nil {
+			sources[i].Filter = DummyLightcurveFilter
+		}
 	}
-	return &LightcurveService{externalClients, lightcurveFilters, conesearchService}, nil
+	return &LightcurveService{sources, conesearchService}, nil
 }
 
 // GetLightcurve retrieves lightcurve data by querying multiple external clients concurrently.
@@ -87,16 +99,22 @@ func New(
 // Returns:
 //   - Lightcurve: Combined lightcurve data from all external clients
 //   - error: Any error encountered during the fetch operation
-func (service *LightcurveService) GetLightcurve(ra, dec, radius float64, nobjects int) (Lightcurve, error) {
+func (service *LightcurveService) GetLightcurve(ra, dec, radius float64, nobjects int, catalog string) (Lightcurve, error) {
+	selectedSources, err := service.selectSources(catalog)
+	if err != nil {
+		return Lightcurve{}, err
+	}
+
 	// Step 1: Fetch external clients and conesearch data concurrently
-	clientData := make(chan ClientResult, len(service.externalClients))
-	service.fetchClientData(clientData, ra, dec, radius, nobjects)
+	clientData := make(chan ClientResult, len(selectedSources))
+	service.fetchClientData(clientData, selectedSources, ra, dec, radius, nobjects)
 	metadataResult := make(chan []conesearch.MetadataResult, 1)
 	errors := make(chan error, 1)
-	service.fetchConesearchData(metadataResult, errors, ra, dec, radius, nobjects)
+	service.fetchConesearchData(metadataResult, errors, ra, dec, radius, nobjects, metadataCatalog(catalog))
 
 	// Wait for all data to be fetched
-	mergedClientResult, err := service.mergeClientResults(clientData)
+	clientResults, err := service.collectClientResults(clientData)
+	mergedClientResult := service.mergeCollectedClientResults(clientResults)
 	if err != nil {
 		return mergedClientResult, err
 	}
@@ -113,7 +131,7 @@ func (service *LightcurveService) GetLightcurve(ra, dec, radius float64, nobject
 	xwaveError := make(chan error, 1)
 	service.getXwaveLightcurve(objectIds, xwaveLightcurve, xwaveError)
 	filteredOutput := make(chan Lightcurve, 1)
-	service.filterLightcurve(filteredOutput, objects, mergedClientResult)
+	service.filterLightcurve(filteredOutput, objects, clientResults)
 
 	// Wait for data to be fetched and filtered. Then merge the results.
 	select {
@@ -134,15 +152,18 @@ func (service *LightcurveService) GetLightcurve(ra, dec, radius float64, nobject
 //   - dec: Declination coordinate in degrees
 //   - radius: Search radius in degrees
 //   - nobjects: Maximum number of objects to retrieve
-func (service *LightcurveService) fetchClientData(output chan<- ClientResult, ra, dec, radius float64, nobjects int) {
+func (service *LightcurveService) fetchClientData(output chan<- ClientResult, sources []Source, ra, dec, radius float64, nobjects int) {
 	var wg sync.WaitGroup
 
-	for _, externalClient := range service.externalClients {
+	for _, source := range sources {
 		wg.Add(1)
-		go func(client ExternalClient) {
+		go func(source Source) {
 			defer wg.Done()
-			output <- client.FetchLightcurve(ra, dec, radius, nobjects)
-		}(externalClient)
+			result := source.Client.FetchLightcurve(ra, dec, radius, nobjects)
+			result.Catalog = source.Catalog
+			result.Filter = source.Filter
+			output <- result
+		}(source)
 	}
 
 	go func() {
@@ -167,11 +188,12 @@ func (service *LightcurveService) fetchConesearchData(
 	errors chan<- error,
 	ra, dec, radius float64,
 	nobjects int,
+	catalog string,
 ) {
 	go func() {
 		defer close(output)
 
-		result, err := service.getObjects(ra, dec, radius, nobjects)
+		result, err := service.getObjects(ra, dec, radius, nobjects, catalog)
 		if err != nil {
 			errors <- err
 			return
@@ -224,8 +246,8 @@ func (service *LightcurveService) extractObjectIds(
 // Returns:
 //   - []MetadataResult: Slice of objects indexed by catalog found in the search area
 //   - error: Any error encountered during the conesearch operation
-func (service *LightcurveService) getObjects(ra, dec, radius float64, neighbors int) ([]conesearch.MetadataResult, error) {
-	objects, err := service.conesearchService.FindMetadataByConesearch(ra, dec, radius, neighbors, "all")
+func (service *LightcurveService) getObjects(ra, dec, radius float64, neighbors int, catalog string) ([]conesearch.MetadataResult, error) {
+	objects, err := service.conesearchService.FindMetadataByConesearch(ra, dec, radius, neighbors, catalog)
 	if err != nil {
 		return nil, fmt.Errorf("could not execute conesearch: %w", err)
 	}
@@ -254,18 +276,71 @@ func (service *LightcurveService) getXwaveLightcurve(_ []string, result chan<- L
 //   - output: Channel to send the filtered lightcurve to
 //   - objects: Metadata objects used for filtering
 //   - lightcurve: Input lightcurve to be filtered
-func (service *LightcurveService) filterLightcurve(output chan<- Lightcurve, objects []conesearch.MetadataResult, lightcurve Lightcurve) {
+func (service *LightcurveService) filterLightcurve(output chan<- Lightcurve, objects []conesearch.MetadataResult, clientResults []ClientResult) {
 	go func() {
 		defer close(output)
 
-		filteredLightcurves := make([]Lightcurve, len(service.lightcurveFilters))
+		filteredLightcurves := make([]Lightcurve, len(clientResults))
 
-		for i := range service.lightcurveFilters {
-			filteredLightcurves[i] = service.lightcurveFilters[i](lightcurve, objects)
+		for i := range clientResults {
+			filter := clientResults[i].Filter
+			if filter == nil {
+				filter = DummyLightcurveFilter
+			}
+			filteredLightcurves[i] = filter(clientResults[i].Lightcurve, objects)
 		}
 
 		output <- service.mergeLightcurves(filteredLightcurves)
 	}()
+}
+
+func (service *LightcurveService) collectClientResults(results <-chan ClientResult) ([]ClientResult, error) {
+	clientResults := make([]ClientResult, 0)
+
+	for result := range results {
+		if result.Error != nil {
+			return clientResults, result.Error
+		}
+
+		clientResults = append(clientResults, result)
+	}
+
+	return clientResults, nil
+}
+
+func (service *LightcurveService) selectSources(catalog string) ([]Source, error) {
+	normalizedCatalog := normalizeCatalog(catalog)
+	if normalizedCatalog == "all" {
+		return service.sources, nil
+	}
+
+	selectedSources := make([]Source, 0)
+	for i := range service.sources {
+		if service.sources[i].Catalog == normalizedCatalog {
+			selectedSources = append(selectedSources, service.sources[i])
+		}
+	}
+	if len(selectedSources) == 0 {
+		return nil, fmt.Errorf("unsupported lightcurve catalog %q", catalog)
+	}
+
+	return selectedSources, nil
+}
+
+func metadataCatalog(catalog string) string {
+	normalizedCatalog := normalizeCatalog(catalog)
+	if normalizedCatalog == "neowise" {
+		return "allwise"
+	}
+	return normalizedCatalog
+}
+
+func normalizeCatalog(catalog string) string {
+	normalizedCatalog := strings.ToLower(catalog)
+	if normalizedCatalog == "allwise" {
+		return "neowise"
+	}
+	return normalizedCatalog
 }
 
 // mergeClientResults merges lightcurve data from multiple external client results received through a channel.
@@ -279,19 +354,21 @@ func (service *LightcurveService) filterLightcurve(output chan<- Lightcurve, obj
 //   - Lightcurve: Merged lightcurve data from all successful clients
 //   - error: First error encountered from any client, if any
 func (service *LightcurveService) mergeClientResults(results <-chan ClientResult) (Lightcurve, error) {
-	lightcurve := Lightcurve{}
-
-	for result := range results {
-		if result.Error != nil {
-			return lightcurve, result.Error
-		}
-
-		lightcurve.Detections = append(lightcurve.Detections, result.Lightcurve.Detections...)
-		lightcurve.NonDetections = append(lightcurve.NonDetections, result.Lightcurve.NonDetections...)
-		lightcurve.ForcedPhotometry = append(lightcurve.ForcedPhotometry, result.Lightcurve.ForcedPhotometry...)
+	clientResults, err := service.collectClientResults(results)
+	if err != nil {
+		return service.mergeCollectedClientResults(clientResults), err
 	}
 
-	return lightcurve, nil
+	return service.mergeCollectedClientResults(clientResults), nil
+}
+
+func (service *LightcurveService) mergeCollectedClientResults(results []ClientResult) Lightcurve {
+	lightcurves := make([]Lightcurve, len(results))
+	for i := range results {
+		lightcurves[i] = results[i].Lightcurve
+	}
+
+	return service.mergeLightcurves(lightcurves)
 }
 
 // mergeLightcurves combines multiple lightcurves into a single lightcurve by concatenating

--- a/service/internal/search/lightcurve/lightcurve_service_regression_test.go
+++ b/service/internal/search/lightcurve/lightcurve_service_regression_test.go
@@ -11,17 +11,25 @@ import (
 
 type stubExternalClient struct {
 	result lc.ClientResult
+	called *int
 }
 
 func (c stubExternalClient) FetchLightcurve(float64, float64, float64, int) lc.ClientResult {
+	if c.called != nil {
+		(*c.called)++
+	}
 	return c.result
 }
 
 type stubConesearchService struct {
-	results []conesearch.MetadataResult
+	results       []conesearch.MetadataResult
+	catalogTarget *string
 }
 
-func (s stubConesearchService) FindMetadataByConesearch(float64, float64, float64, int, string) ([]conesearch.MetadataResult, error) {
+func (s *stubConesearchService) FindMetadataByConesearch(_, _, _ float64, _ int, catalog string) ([]conesearch.MetadataResult, error) {
+	if s.catalogTarget != nil {
+		*s.catalogTarget = catalog
+	}
 	return s.results, nil
 }
 
@@ -40,21 +48,22 @@ func (m metadataStub) GetCatalog() string {
 
 func TestGetLightcurve_AppliesZtfDrFilter(t *testing.T) {
 	service, err := lc.New(
-		[]lc.ExternalClient{stubExternalClient{
-			result: lc.ClientResult{Lightcurve: lc.Lightcurve{Detections: []lc.LightcurveObject{
+		[]lc.Source{{
+			Catalog: "ztf",
+			Client: stubExternalClient{result: lc.ClientResult{Lightcurve: lc.Lightcurve{Detections: []lc.LightcurveObject{
 				ztfdr.Detection{Oid: 1, Hmjd: 1},
 				ztfdr.Detection{Oid: 2, Hmjd: 2},
-			}}},
+			}}}},
+			Filter: ztfdr.Filter,
 		}},
-		[]lc.LightcurveFilter{ztfdr.Filter},
-		stubConesearchService{results: []conesearch.MetadataResult{{
+		&stubConesearchService{results: []conesearch.MetadataResult{{
 			Catalog: "ztf",
 			Data:    []conesearch.MetadataExtended{{Metadata: metadataStub{id: "1", catalog: "ztf"}}},
 		}}},
 	)
 	require.NoError(t, err)
 
-	result, err := service.GetLightcurve(10, -10, 0.2, 10)
+	result, err := service.GetLightcurve(10, -10, 0.2, 10, "ztf")
 	require.NoError(t, err)
 	require.Len(t, result.Detections, 1)
 	require.Equal(t, "1", result.Detections[0].GetObjectId())
@@ -62,17 +71,118 @@ func TestGetLightcurve_AppliesZtfDrFilter(t *testing.T) {
 
 func TestGetLightcurve_ReturnsClientDataWhenConesearchHasNoMatches(t *testing.T) {
 	service, err := lc.New(
-		[]lc.ExternalClient{stubExternalClient{
-			result: lc.ClientResult{Lightcurve: lc.Lightcurve{Detections: []lc.LightcurveObject{
+		[]lc.Source{{
+			Catalog: "ztf",
+			Client: stubExternalClient{result: lc.ClientResult{Lightcurve: lc.Lightcurve{Detections: []lc.LightcurveObject{
 				ztfdr.Detection{Oid: 1, Hmjd: 1},
-			}}},
+			}}}},
+			Filter: ztfdr.Filter,
 		}},
-		[]lc.LightcurveFilter{ztfdr.Filter},
-		stubConesearchService{},
+		&stubConesearchService{},
 	)
 	require.NoError(t, err)
 
-	result, err := service.GetLightcurve(10, -10, 0.2, 10)
+	result, err := service.GetLightcurve(10, -10, 0.2, 10, "ztf")
+	require.NoError(t, err)
+	require.Len(t, result.Detections, 1)
+	require.Equal(t, "1", result.Detections[0].GetObjectId())
+}
+
+func TestGetLightcurve_ExecutesOnlySelectedCatalogClient(t *testing.T) {
+	ztfCalls := 0
+	neowiseCalls := 0
+	conesearchCatalog := ""
+
+	service, err := lc.New(
+		[]lc.Source{
+			{
+				Catalog: "ztf",
+				Client: stubExternalClient{
+					called: &ztfCalls,
+					result: lc.ClientResult{Lightcurve: lc.Lightcurve{Detections: []lc.LightcurveObject{ztfdr.Detection{Oid: 1, Hmjd: 1}}}},
+				},
+				Filter: ztfdr.Filter,
+			},
+			{
+				Catalog: "neowise",
+				Client:  stubExternalClient{called: &neowiseCalls},
+				Filter:  lc.DummyLightcurveFilter,
+			},
+		},
+		&stubConesearchService{
+			catalogTarget: &conesearchCatalog,
+			results: []conesearch.MetadataResult{{
+				Catalog: "ztf",
+				Data:    []conesearch.MetadataExtended{{Metadata: metadataStub{id: "1", catalog: "ztf"}}},
+			}},
+		},
+	)
+	require.NoError(t, err)
+
+	result, err := service.GetLightcurve(10, -10, 0.2, 10, "ztf")
+	require.NoError(t, err)
+	require.Len(t, result.Detections, 1)
+	require.Equal(t, 1, ztfCalls)
+	require.Equal(t, 0, neowiseCalls)
+	require.Equal(t, "ztf", conesearchCatalog)
+}
+
+func TestGetLightcurve_AllwiseAliasUsesNeowiseSource(t *testing.T) {
+	ztfCalls := 0
+	neowiseCalls := 0
+	conesearchCatalog := ""
+
+	service, err := lc.New(
+		[]lc.Source{
+			{
+				Catalog: "ztf",
+				Client:  stubExternalClient{called: &ztfCalls},
+				Filter:  lc.DummyLightcurveFilter,
+			},
+			{
+				Catalog: "neowise",
+				Client: stubExternalClient{
+					called: &neowiseCalls,
+					result: lc.ClientResult{Lightcurve: lc.Lightcurve{}},
+				},
+				Filter: lc.DummyLightcurveFilter,
+			},
+		},
+		&stubConesearchService{catalogTarget: &conesearchCatalog},
+	)
+	require.NoError(t, err)
+
+	_, err = service.GetLightcurve(10, -10, 0.2, 10, "allwise")
+	require.NoError(t, err)
+	require.Equal(t, 0, ztfCalls)
+	require.Equal(t, 1, neowiseCalls)
+	require.Equal(t, "allwise", conesearchCatalog)
+}
+
+func TestGetLightcurve_AllCatalogDoesNotDuplicateFilteredSource(t *testing.T) {
+	service, err := lc.New(
+		[]lc.Source{
+			{
+				Catalog: "ztf",
+				Client: stubExternalClient{result: lc.ClientResult{Lightcurve: lc.Lightcurve{Detections: []lc.LightcurveObject{
+					ztfdr.Detection{Oid: 1, Hmjd: 1},
+				}}}},
+				Filter: ztfdr.Filter,
+			},
+			{
+				Catalog: "neowise",
+				Client:  stubExternalClient{result: lc.ClientResult{Lightcurve: lc.Lightcurve{}}},
+				Filter:  lc.DummyLightcurveFilter,
+			},
+		},
+		&stubConesearchService{results: []conesearch.MetadataResult{{
+			Catalog: "ztf",
+			Data:    []conesearch.MetadataExtended{{Metadata: metadataStub{id: "1", catalog: "ztf"}}},
+		}}},
+	)
+	require.NoError(t, err)
+
+	result, err := service.GetLightcurve(10, -10, 0.2, 10, "all")
 	require.NoError(t, err)
 	require.Len(t, result.Detections, 1)
 	require.Equal(t, "1", result.Detections[0].GetObjectId())

--- a/service/internal/search/lightcurve/lightcurve_service_test.go
+++ b/service/internal/search/lightcurve/lightcurve_service_test.go
@@ -68,6 +68,10 @@ func MockLightcurveFilter(Lightcurve, []conesearch.MetadataResult) Lightcurve {
 	return Lightcurve{}
 }
 
+func testSource(client ExternalClient) Source {
+	return Source{Catalog: "ztf", Client: client, Filter: MockLightcurveFilter}
+}
+
 func TestGetObjectIds_Empty(t *testing.T) {
 	mockService := NewMockConesearchService(t)
 	mockService.EXPECT().FindMetadataByConesearch(
@@ -75,13 +79,13 @@ func TestGetObjectIds_Empty(t *testing.T) {
 		mock.AnythingOfType("float64"),
 		mock.AnythingOfType("float64"),
 		1,
-		"all",
+		"ztf",
 	).Return([]conesearch.MetadataResult{}, nil)
 
-	lightcurveService, err := New([]ExternalClient{NewMockExternalClient(t)}, []LightcurveFilter{MockLightcurveFilter}, mockService)
+	lightcurveService, err := New([]Source{testSource(NewMockExternalClient(t))}, mockService)
 	require.NoError(t, err)
 
-	objs, err := lightcurveService.getObjects(0, 0, 0, 1)
+	objs, err := lightcurveService.getObjects(0, 0, 0, 1, "ztf")
 	require.NoError(t, err)
 
 	require.Equal(t, []conesearch.MetadataResult{}, objs)
@@ -94,7 +98,7 @@ func TestGetObjectIds_NonEmpty(t *testing.T) {
 		mock.AnythingOfType("float64"),
 		mock.AnythingOfType("float64"),
 		1,
-		"all",
+		"allwise",
 	).Return([]conesearch.MetadataResult{
 		{
 			Catalog: "allwise",
@@ -106,10 +110,10 @@ func TestGetObjectIds_NonEmpty(t *testing.T) {
 		},
 	}, nil)
 
-	lightcurveService, err := New([]ExternalClient{NewMockExternalClient(t)}, []LightcurveFilter{MockLightcurveFilter}, mockService)
+	lightcurveService, err := New([]Source{testSource(NewMockExternalClient(t))}, mockService)
 	require.NoError(t, err)
 
-	objs, err := lightcurveService.getObjects(0, 0, 0, 1)
+	objs, err := lightcurveService.getObjects(0, 0, 0, 1, "allwise")
 	require.NoError(t, err)
 
 	ids := make([]string, 0)
@@ -141,7 +145,7 @@ func TestMergeClientResults_NoError(t *testing.T) {
 	results <- clientResult2
 	close(results)
 
-	lightcurveService, err := New([]ExternalClient{NewMockExternalClient(t)}, []LightcurveFilter{MockLightcurveFilter}, NewMockConesearchService(t))
+	lightcurveService, err := New([]Source{testSource(NewMockExternalClient(t))}, NewMockConesearchService(t))
 	require.NoError(t, err)
 
 	lightcurve, err := lightcurveService.mergeClientResults(results)
@@ -175,7 +179,7 @@ func TestMergeClientResults_WithError(t *testing.T) {
 	results <- clientResult3
 	close(results)
 
-	lightcurveService, err := New([]ExternalClient{NewMockExternalClient(t)}, []LightcurveFilter{MockLightcurveFilter}, NewMockConesearchService(t))
+	lightcurveService, err := New([]Source{testSource(NewMockExternalClient(t))}, NewMockConesearchService(t))
 	require.NoError(t, err)
 
 	lightcurve, err := lightcurveService.mergeClientResults(results)
@@ -187,7 +191,7 @@ func TestMergeClientResults_WithError(t *testing.T) {
 }
 
 func TestExtractObjectIds_PreservesCatalog(t *testing.T) {
-	lightcurveService, err := New([]ExternalClient{NewMockExternalClient(t)}, []LightcurveFilter{MockLightcurveFilter}, NewMockConesearchService(t))
+	lightcurveService, err := New([]Source{testSource(NewMockExternalClient(t))}, NewMockConesearchService(t))
 	require.NoError(t, err)
 
 	metadataResult := make(chan []conesearch.MetadataResult, 1)
@@ -219,7 +223,7 @@ func TestMergeLightcurves(t *testing.T) {
 		Detections: []LightcurveObject{TestDetection{"2", "GAIA1", 1, 1, 1}},
 	}
 
-	service, err := New([]ExternalClient{NewMockExternalClient(t)}, []LightcurveFilter{MockLightcurveFilter}, NewMockConesearchService(t))
+	service, err := New([]Source{testSource(NewMockExternalClient(t))}, NewMockConesearchService(t))
 	require.NoError(t, err)
 
 	result := service.mergeLightcurves([]Lightcurve{lightcurve1, lightcurve2})


### PR DESCRIPTION
Add catalog filter to lightcurve endpoint. Example: `/lightcurve?ra=148.8882055&dec=69.0652993&radius=0.1&catalog=ztf`